### PR TITLE
Add token-based auth for enterprise use

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,28 +155,35 @@ $ mcpjungle register --name huggingface --description "HuggingFace MCP Server" -
 
 Support for Oauth flow is coming soon!
 
-### Enterprise Features
+### Enterprise Features 🔒
 
 If you're running MCPJungle in your organisation, we recommend running the Server in the `production` mode:
 ```bash
-# enable enterprise features like authentication
+# enable enterprise features by running in production mode
 $ mcpjungle start --prod
 
-# server must be initialized before use
-$ mcpjungle init-server
+# you can also specify the server mode as environment variable (valid values are `development` and `production`)
+# this is convenient when using docker-compose or running the server in a container
+$ export SERVER_MODE=production
+$ mcpjungle start
 ```
 
 By default, mcpjungle server runs in `development` mode which is ideal for individuals running it locally.
 
 In Production mode, the server enforces stricter security & compliance policies and will provide additional features like Authentication, ACLs, observability and more.
 
-Once you run a server in production mode, you must initialize it by running the `init-server` command on your client machine.
+After starting the server in production mode, you must initialize it by running the following command on your client machine:
+```bash
+$ mcpjungle init-server
+```
 
-This will create an admin user in the server and store its API access token in your home directory (`~/.mcpjungle.conf`). You can then use the mcpjungle cli to make authenticated requests to the server.
+This will create an admin user in the server and store its API access token in your home directory (`~/.mcpjungle.conf`).
 
-## Development
+You can then use the mcpjungle cli to make authenticated requests to the server.
 
-This section contains notes for maintainers and contributors of MCPJungle.
+## Contributing 💻
+
+This section contains notes for Developers and Contributors of MCPJungle. Users can skip this section.
 
 ### Build for local testing
 ```bash

--- a/README.md
+++ b/README.md
@@ -155,6 +155,25 @@ $ mcpjungle register --name huggingface --description "HuggingFace MCP Server" -
 
 Support for Oauth flow is coming soon!
 
+### Enterprise Features
+
+If you're running MCPJungle in your organisation, we recommend running the Server in the `production` mode:
+```bash
+# enable enterprise features like authentication
+$ mcpjungle start --prod
+
+# server must be initialized before use
+$ mcpjungle init-server
+```
+
+By default, mcpjungle server runs in `development` mode which is ideal for individuals running it locally.
+
+In Production mode, the server enforces stricter security & compliance policies and will provide additional features like Authentication, ACLs, observability and more.
+
+Once you run a server in production mode, you must initialize it by running the `init-server` command on your client machine.
+
+This will create an admin user in the server and store its API access token in your home directory (`~/.mcpjungle.conf`). You can then use the mcpjungle cli to make authenticated requests to the server.
+
 ## Development
 
 This section contains notes for maintainers and contributors of MCPJungle.

--- a/client/client.go
+++ b/client/client.go
@@ -13,14 +13,14 @@ import (
 
 // Client represents a client for interacting with the MCPJungle HTTP API
 type Client struct {
-	BaseURL    string
-	HTTPClient *http.Client
+	baseURL    string
+	httpClient *http.Client
 }
 
 func NewClient(baseURL string, httpClient *http.Client) *Client {
 	return &Client{
-		BaseURL:    baseURL,
-		HTTPClient: httpClient,
+		baseURL:    baseURL,
+		httpClient: httpClient,
 	}
 }
 
@@ -30,7 +30,7 @@ type InitServerResponse struct {
 
 // InitServer sends a request to initialize the server in production mode
 func (c *Client) InitServer() (*InitServerResponse, error) {
-	u, _ := url.JoinPath(c.BaseURL, "/init")
+	u, _ := url.JoinPath(c.baseURL, "/init")
 
 	payload := struct {
 		Mode string `json:"mode"`
@@ -42,7 +42,7 @@ func (c *Client) InitServer() (*InitServerResponse, error) {
 		return nil, err
 	}
 
-	resp, err := c.HTTPClient.Post(u, "application/json", bytes.NewBuffer(body))
+	resp, err := c.httpClient.Post(u, "application/json", bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request to %s: %w", u, err)
 	}
@@ -62,5 +62,5 @@ func (c *Client) InitServer() (*InitServerResponse, error) {
 
 // constructAPIEndpoint constructs the full API endpoint URL where a request must be sent
 func (c *Client) constructAPIEndpoint(suffixPath string) (string, error) {
-	return url.JoinPath(c.BaseURL, api.V0PathPrefix, suffixPath)
+	return url.JoinPath(c.baseURL, api.V0PathPrefix, suffixPath)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -13,14 +13,16 @@ import (
 
 // Client represents a client for interacting with the MCPJungle HTTP API
 type Client struct {
-	baseURL    string
-	httpClient *http.Client
+	baseURL     string
+	accessToken string
+	httpClient  *http.Client
 }
 
-func NewClient(baseURL string, httpClient *http.Client) *Client {
+func NewClient(baseURL string, accessToken string, httpClient *http.Client) *Client {
 	return &Client{
-		baseURL:    baseURL,
-		httpClient: httpClient,
+		baseURL:     baseURL,
+		accessToken: accessToken,
+		httpClient:  httpClient,
 	}
 }
 
@@ -63,4 +65,17 @@ func (c *Client) InitServer() (*InitServerResponse, error) {
 // constructAPIEndpoint constructs the full API endpoint URL where a request must be sent
 func (c *Client) constructAPIEndpoint(suffixPath string) (string, error) {
 	return url.JoinPath(c.baseURL, api.V0PathPrefix, suffixPath)
+}
+
+// newRequest creates a new HTTP request with the specified method, URL, and body.
+// It automatically adds the Authorization header if an access token is present.
+func (c *Client) newRequest(method, url string, body io.Reader) (*http.Request, error) {
+	req, err := http.NewRequest(method, url, body)
+	if err != nil {
+		return nil, err
+	}
+	if c.accessToken != "" {
+		req.Header.Set("Authorization", "Bearer "+c.accessToken)
+	}
+	return req, nil
 }

--- a/client/client.go
+++ b/client/client.go
@@ -24,8 +24,12 @@ func NewClient(baseURL string, httpClient *http.Client) *Client {
 	}
 }
 
+type InitServerResponse struct {
+	AdminAccessToken string `json:"admin_access_token"`
+}
+
 // InitServer sends a request to initialize the server in production mode
-func (c *Client) InitServer() error {
+func (c *Client) InitServer() (*InitServerResponse, error) {
 	u, _ := url.JoinPath(c.BaseURL, "/init")
 
 	payload := struct {
@@ -35,21 +39,25 @@ func (c *Client) InitServer() error {
 	}
 	body, err := json.Marshal(payload)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	resp, err := c.HTTPClient.Post(u, "application/json", bytes.NewBuffer(body))
 	if err != nil {
-		return fmt.Errorf("failed to send request to %s: %w", u, err)
+		return nil, fmt.Errorf("failed to send request to %s: %w", u, err)
 	}
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
 	}
 
-	return nil
+	var initResp InitServerResponse
+	if err := json.NewDecoder(resp.Body).Decode(&initResp); err != nil {
+		return nil, fmt.Errorf("failed to decode response: %w", err)
+	}
+	return &initResp, nil
 }
 
 // constructAPIEndpoint constructs the full API endpoint URL where a request must be sent

--- a/client/client.go
+++ b/client/client.go
@@ -1,7 +1,12 @@
 package client
 
 import (
+	"bytes"
+	"encoding/json"
+	"fmt"
 	"github.com/mcpjungle/mcpjungle/internal/api"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"io"
 	"net/http"
 	"net/url"
 )
@@ -17,6 +22,34 @@ func NewClient(baseURL string, httpClient *http.Client) *Client {
 		BaseURL:    baseURL,
 		HTTPClient: httpClient,
 	}
+}
+
+// InitServer sends a request to initialize the server in production mode
+func (c *Client) InitServer() error {
+	u, _ := url.JoinPath(c.BaseURL, "/init")
+
+	payload := struct {
+		Mode string `json:"mode"`
+	}{
+		Mode: string(model.ModeProd),
+	}
+	body, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.HTTPClient.Post(u, "application/json", bytes.NewBuffer(body))
+	if err != nil {
+		return fmt.Errorf("failed to send request to %s: %w", u, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+	}
+
+	return nil
 }
 
 // constructAPIEndpoint constructs the full API endpoint URL where a request must be sent

--- a/client/mcp_server.go
+++ b/client/mcp_server.go
@@ -37,7 +37,13 @@ func (c *Client) RegisterServer(server *RegisterServerInput) (*Server, error) {
 		return nil, fmt.Errorf("failed to serialize server data into JSON: %w", err)
 	}
 
-	resp, err := c.httpClient.Post(u, "application/json", bytes.NewBuffer(body))
+	req, err := c.newRequest(http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request to %s: %w", u, err)
 	}
@@ -58,7 +64,12 @@ func (c *Client) RegisterServer(server *RegisterServerInput) (*Server, error) {
 // ListServers fetches the list of registered servers.
 func (c *Client) ListServers() ([]*Server, error) {
 	u, _ := c.constructAPIEndpoint("/servers")
-	resp, err := c.httpClient.Get(u)
+	req, err := c.newRequest(http.MethodGet, u, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request to %s: %w", u, err)
 	}
@@ -79,7 +90,7 @@ func (c *Client) ListServers() ([]*Server, error) {
 // DeregisterServer deletes a server by name.
 func (c *Client) DeregisterServer(name string) error {
 	u, _ := c.constructAPIEndpoint("/servers/" + name)
-	req, _ := http.NewRequest(http.MethodDelete, u, nil)
+	req, _ := c.newRequest(http.MethodDelete, u, nil)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/client/mcp_server.go
+++ b/client/mcp_server.go
@@ -37,7 +37,7 @@ func (c *Client) RegisterServer(server *RegisterServerInput) (*Server, error) {
 		return nil, fmt.Errorf("failed to serialize server data into JSON: %w", err)
 	}
 
-	resp, err := c.HTTPClient.Post(u, "application/json", bytes.NewBuffer(body))
+	resp, err := c.httpClient.Post(u, "application/json", bytes.NewBuffer(body))
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request to %s: %w", u, err)
 	}
@@ -58,7 +58,7 @@ func (c *Client) RegisterServer(server *RegisterServerInput) (*Server, error) {
 // ListServers fetches the list of registered servers.
 func (c *Client) ListServers() ([]*Server, error) {
 	u, _ := c.constructAPIEndpoint("/servers")
-	resp, err := c.HTTPClient.Get(u)
+	resp, err := c.httpClient.Get(u)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request to %s: %w", u, err)
 	}
@@ -81,7 +81,7 @@ func (c *Client) DeregisterServer(name string) error {
 	u, _ := c.constructAPIEndpoint("/servers/" + name)
 	req, _ := http.NewRequest(http.MethodDelete, u, nil)
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed to send request to %s: %w", u, err)
 	}

--- a/client/mcp_tool.go
+++ b/client/mcp_tool.go
@@ -31,7 +31,7 @@ type ToolInvokeResult struct {
 // ListTools fetches the list of tools, optionally filtered by server name.
 func (c *Client) ListTools(server string) ([]*Tool, error) {
 	u, _ := c.constructAPIEndpoint("/tools")
-	req, _ := http.NewRequest(http.MethodGet, u, nil)
+	req, _ := c.newRequest(http.MethodGet, u, nil)
 	if server != "" {
 		q := req.URL.Query()
 		q.Add("server", server)
@@ -58,7 +58,7 @@ func (c *Client) ListTools(server string) ([]*Tool, error) {
 // GetTool fetches a specific tool by its name.
 func (c *Client) GetTool(name string) (*Tool, error) {
 	u, _ := c.constructAPIEndpoint("/tool")
-	req, _ := http.NewRequest(http.MethodGet, u, nil)
+	req, _ := c.newRequest(http.MethodGet, u, nil)
 	q := req.URL.Query()
 	q.Add("name", name)
 	req.URL.RawQuery = q.Encode()
@@ -95,7 +95,13 @@ func (c *Client) InvokeTool(name string, input map[string]any) (*ToolInvokeResul
 
 	body, _ := json.Marshal(payload)
 	u, _ := c.constructAPIEndpoint("/tools/invoke")
-	resp, err := c.httpClient.Post(u, "application/json", bytes.NewReader(body))
+	req, err := c.newRequest(http.MethodPost, u, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("request to server failed: %w", err)
 	}

--- a/client/mcp_tool.go
+++ b/client/mcp_tool.go
@@ -38,7 +38,7 @@ func (c *Client) ListTools(server string) ([]*Tool, error) {
 		req.URL.RawQuery = q.Encode()
 	}
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request to %s: %w", req.URL.String(), err)
 	}
@@ -63,7 +63,7 @@ func (c *Client) GetTool(name string) (*Tool, error) {
 	q.Add("name", name)
 	req.URL.RawQuery = q.Encode()
 
-	resp, err := c.HTTPClient.Do(req)
+	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("failed to send request to %s: %w", req.URL.String(), err)
 	}
@@ -95,7 +95,7 @@ func (c *Client) InvokeTool(name string, input map[string]any) (*ToolInvokeResul
 
 	body, _ := json.Marshal(payload)
 	u, _ := c.constructAPIEndpoint("/tools/invoke")
-	resp, err := c.HTTPClient.Post(u, "application/json", bytes.NewReader(body))
+	resp, err := c.httpClient.Post(u, "application/json", bytes.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("request to server failed: %w", err)
 	}

--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+	"os"
+	"path/filepath"
+)
+
+const ClientConfigFileName = ".mcpjungle.conf"
+
+// ClientConfig represents the MCPJungle client configuration stored in the user's home directory.
+type ClientConfig struct {
+	AccessToken string `yaml:"access_token"`
+}
+
+// AbsPath returns the absolute path to the client configuration file.
+// It combines the user's home directory with the ClientConfigFileName.
+// The path is returned regardless of whether the file actually exists there or not.
+func AbsPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ClientConfigFileName), nil
+}
+
+// Save saves the ClientConfig to the file system at AbsPath().
+// If the file does not exist, this method creates it.
+func Save(c *ClientConfig) error {
+	path, err := AbsPath()
+	if err != nil {
+		return err
+	}
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	encoder := yaml.NewEncoder(f)
+	defer encoder.Close()
+	return encoder.Encode(c)
+}
+
+// Load loads the client configuration from the user's home directory on best-effort basis.
+// If this function encounters any errors (or the config does not exist), it simply returns an empty ClientConfig.
+func Load() *ClientConfig {
+	cfg := &ClientConfig{}
+
+	path, err := AbsPath()
+	if err != nil {
+		return cfg
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return cfg
+	}
+	defer f.Close()
+
+	decoder := yaml.NewDecoder(f)
+	_ = decoder.Decode(cfg)
+
+	return cfg
+}

--- a/cmd/init_server.go
+++ b/cmd/init_server.go
@@ -19,10 +19,16 @@ func init() {
 
 func runInitServer(cmd *cobra.Command, args []string) error {
 	fmt.Println("Initializing the MCPJungle Server in Production Mode...")
-	err := apiClient.InitServer()
+	resp, err := apiClient.InitServer()
 	if err != nil {
 		return fmt.Errorf("failed to initialize the server: %w", err)
 	}
+
+	if resp.AdminAccessToken == "" {
+		return fmt.Errorf("server initialization failed: no admin access token received")
+	}
+	fmt.Println("Your Admin access token is:", resp.AdminAccessToken)
+
 	fmt.Println("Done!")
 	return nil
 }

--- a/cmd/init_server.go
+++ b/cmd/init_server.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/mcpjungle/mcpjungle/cmd/config"
 	"github.com/spf13/cobra"
 )
 
@@ -27,8 +28,21 @@ func runInitServer(cmd *cobra.Command, args []string) error {
 	if resp.AdminAccessToken == "" {
 		return fmt.Errorf("server initialization failed: no admin access token received")
 	}
-	fmt.Println("Your Admin access token is:", resp.AdminAccessToken)
 
-	fmt.Println("Done!")
+	// Create new client configuration
+	cfg := &config.ClientConfig{
+		AccessToken: resp.AdminAccessToken,
+	}
+	if err := config.Save(cfg); err != nil {
+		return fmt.Errorf("failed to create client configuration: %w", err)
+	}
+
+	cfgPath, err := config.AbsPath()
+	if err != nil {
+		return fmt.Errorf("failed to get client configuration path: %w", err)
+	}
+	fmt.Println("Your Admin access token has been saved to", cfgPath)
+
+	fmt.Println("All done!")
 	return nil
 }

--- a/cmd/init_server.go
+++ b/cmd/init_server.go
@@ -1,0 +1,28 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var initServerCmd = &cobra.Command{
+	Use:   "init-server",
+	Short: "Initialize the MCPJungle Server (for Production Mode only)",
+	Long: "If the MCPJungle Server was started in Production Mode, use this command to initialize the server.\n" +
+		"Initialization is required before you can use the server.\n",
+	RunE: runInitServer,
+}
+
+func init() {
+	rootCmd.AddCommand(initServerCmd)
+}
+
+func runInitServer(cmd *cobra.Command, args []string) error {
+	fmt.Println("Initializing the MCPJungle Server in Production Mode...")
+	err := apiClient.InitServer()
+	if err != nil {
+		return fmt.Errorf("failed to initialize the server: %w", err)
+	}
+	fmt.Println("Done!")
+	return nil
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"github.com/mcpjungle/mcpjungle/client"
+	"github.com/mcpjungle/mcpjungle/cmd/config"
 	"github.com/spf13/cobra"
 	"net/http"
 )
@@ -47,9 +48,10 @@ func Execute() error {
 		"Base URL of the MCPJungle registry server",
 	)
 
-	// Initialize the API client with the registry server URL
+	// Initialize the API client with the registry server URL & client configuration (if any)
 	rootCmd.PersistentPreRun = func(cmd *cobra.Command, args []string) {
-		apiClient = client.NewClient(registryServerURL, http.DefaultClient)
+		cfg := config.Load()
+		apiClient = client.NewClient(registryServerURL, cfg.AccessToken, http.DefaultClient)
 	}
 
 	return rootCmd.Execute()

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -17,7 +17,10 @@ const (
 	BindPortDefault = "8080"
 )
 
-var startServerCmdBindPort string
+var (
+	startServerCmdBindPort    string
+	startServerCmdProdEnabled bool
+)
 
 var startServerCmd = &cobra.Command{
 	Use:   "start",
@@ -32,6 +35,13 @@ func init() {
 		"",
 		fmt.Sprintf("port to bind the server to (overrides env var %s)", BindPortEnvVar),
 	)
+	startServerCmd.Flags().BoolVar(
+		&startServerCmdProdEnabled,
+		"prod",
+		false,
+		fmt.Sprintf("Run server in production mode (for enterprises)"),
+	)
+
 	rootCmd.AddCommand(startServerCmd)
 }
 
@@ -44,6 +54,9 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	// Migrations should ideally be decoupled from both the server and the startup phase
+	// (should be run as a separate command).
+	// However, for the user's convenience, we run them as part of startup command for now.
 	if err := migrations.Migrate(dbConn); err != nil {
 		return fmt.Errorf("failed to run migrations: %v", err)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,6 +10,7 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/model"
 	"github.com/mcpjungle/mcpjungle/internal/service/config"
 	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
+	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -87,6 +88,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 	}
 
 	configService := config.NewServerConfigService(dbConn)
+	userService := user.NewUserService(dbConn)
 
 	// create the API server
 	opts := &api.ServerOptions{
@@ -94,6 +96,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		MCPProxyServer: mcpProxyServer,
 		MCPService:     mcpService,
 		ConfigService:  configService,
+		UserService:    userService,
 	}
 	s, err := api.NewServer(opts)
 	if err != nil {
@@ -126,7 +129,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		// If server isn't already initialized and the desired mode is dev, silently initialize the server.
 		// Individual (dev mode) users need not worry about server initialization.
 		if desiredMode == model.ModeDev {
-			if err := s.Init(desiredMode); err != nil {
+			if err := s.InitDev(); err != nil {
 				return fmt.Errorf("failed to initialize server in development mode: %v", err)
 			}
 		} else {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -8,8 +8,8 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/db"
 	"github.com/mcpjungle/mcpjungle/internal/migrations"
 	"github.com/mcpjungle/mcpjungle/internal/model"
-	"github.com/mcpjungle/mcpjungle/internal/service"
 	"github.com/mcpjungle/mcpjungle/internal/service/config"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
 	"github.com/spf13/cobra"
 	"os"
 )
@@ -79,7 +79,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		server.WithToolCapabilities(true),
 	)
 
-	mcpService, err := service.NewMCPService(dbConn, mcpProxyServer)
+	mcpService, err := mcp.NewMCPService(dbConn, mcpProxyServer)
 	if err != nil {
 		return fmt.Errorf("failed to create MCP service: %v", err)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -136,7 +136,8 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 			// If desired mode is prod, then server initialization is a manual next step to be taken by the user.
 			// This is so that they can obtain the admin access token on their client machine.
 			fmt.Println(
-				"Starting server in Production mode, don't forget to initialize it by running `init-server`",
+				"Starting server in Production mode," +
+					" don't forget to initialize it by running the `init-server` command",
 			)
 		}
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -136,9 +136,9 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	fmt.Printf("MCPJungle HTTP server listening on :%s", port)
+	fmt.Printf("MCPJungle HTTP server listening on :%s\n\n", port)
 	if err := s.Start(); err != nil {
-		return fmt.Errorf("failed to run the server: %v", err)
+		return fmt.Errorf("failed to run the server: %v\n", err)
 	}
 
 	return nil

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -87,7 +87,13 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 	configService := config.NewServerConfigService(dbConn)
 
 	// create the API server
-	s, err := api.NewServer(port, mcpProxyServer, mcpService, configService)
+	opts := &api.ServerOptions{
+		Port:           port,
+		MCPProxyServer: mcpProxyServer,
+		MCPService:     mcpService,
+		ConfigService:  configService,
+	}
+	s, err := api.NewServer(opts)
 	if err != nil {
 		return fmt.Errorf("failed to create server: %v", err)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,7 +27,9 @@ var (
 var startServerCmd = &cobra.Command{
 	Use:   "start",
 	Short: "Start the MCP registry server",
-	RunE:  runStartServer,
+	Long: "Starts the MCPJungle HTTP registry server and the MCP Proxy server.\n" +
+		"The server is started in Development mode by default, which is ideal for individual users.\n",
+	RunE: runStartServer,
 }
 
 func init() {
@@ -41,7 +43,7 @@ func init() {
 		&startServerCmdProdEnabled,
 		"prod",
 		false,
-		fmt.Sprintf("Run server in production mode (for enterprises)"),
+		fmt.Sprintf("Run the server in Production mode (suitable for enterprises)"),
 	)
 
 	rootCmd.AddCommand(startServerCmd)

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/joho/godotenv v1.5.1
 	github.com/mark3labs/mcp-go v0.32.0
 	github.com/spf13/cobra v1.9.1
+	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.2.5
 	gorm.io/driver/postgres v1.5.11
 	gorm.io/gorm v1.26.1
@@ -57,7 +58,6 @@ require (
 	golang.org/x/sys v0.33.0 // indirect
 	golang.org/x/text v0.25.0 // indirect
 	google.golang.org/protobuf v1.36.6 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	gorm.io/driver/mysql v1.5.6 // indirect
 	gorm.io/driver/sqlite v1.5.7 // indirect
 	modernc.org/libc v1.22.5 // indirect

--- a/internal/api/mcp_servers.go
+++ b/internal/api/mcp_servers.go
@@ -3,11 +3,11 @@ package api
 import (
 	"github.com/gin-gonic/gin"
 	"github.com/mcpjungle/mcpjungle/internal/model"
-	"github.com/mcpjungle/mcpjungle/internal/service"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
 	"net/http"
 )
 
-func registerServerHandler(mcpService *service.MCPService) gin.HandlerFunc {
+func registerServerHandler(mcpService *mcp.MCPService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req model.McpServer
 		if err := c.ShouldBindJSON(&req); err != nil {
@@ -22,7 +22,7 @@ func registerServerHandler(mcpService *service.MCPService) gin.HandlerFunc {
 	}
 }
 
-func deregisterServerHandler(mcpService *service.MCPService) gin.HandlerFunc {
+func deregisterServerHandler(mcpService *mcp.MCPService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		name := c.Param("name")
 		if err := mcpService.DeregisterMcpServer(name); err != nil {
@@ -33,7 +33,7 @@ func deregisterServerHandler(mcpService *service.MCPService) gin.HandlerFunc {
 	}
 }
 
-func listServersHandler(mcpService *service.MCPService) gin.HandlerFunc {
+func listServersHandler(mcpService *mcp.MCPService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		servers, err := mcpService.ListMcpServers()
 		if err != nil {

--- a/internal/api/mcp_tools.go
+++ b/internal/api/mcp_tools.go
@@ -6,10 +6,10 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/mcpjungle/mcpjungle/internal/service"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
 )
 
-func listToolsHandler(mcpService *service.MCPService) gin.HandlerFunc {
+func listToolsHandler(mcpService *mcp.MCPService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		server := c.Query("server")
 		var (
@@ -32,7 +32,7 @@ func listToolsHandler(mcpService *service.MCPService) gin.HandlerFunc {
 }
 
 // invokeToolHandler forwards the JSON body to the tool URL and streams response back.
-func invokeToolHandler(mcpService *service.MCPService) gin.HandlerFunc {
+func invokeToolHandler(mcpService *mcp.MCPService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var args map[string]any
 		if err := json.NewDecoder(c.Request.Body).Decode(&args); err != nil {
@@ -68,7 +68,7 @@ func invokeToolHandler(mcpService *service.MCPService) gin.HandlerFunc {
 }
 
 // getToolHandler returns the tool with the given name.
-func getToolHandler(mcpService *service.MCPService) gin.HandlerFunc {
+func getToolHandler(mcpService *mcp.MCPService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// tool name has to be supplied as a query param because it contains slash.
 		// cannot be supplied as a path param.

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -38,6 +38,29 @@ func NewServer(port string, mcpProxyServer *server.MCPServer, mcpService *mcp.MC
 	return s, nil
 }
 
+func (s *Server) IsInitialized() (bool, error) {
+	c, err := s.configService.GetConfig()
+	if err != nil {
+		return false, fmt.Errorf("failed to get server config: %w", err)
+	}
+	return c.Initialized, nil
+}
+
+func (s *Server) GetMode() (model.ServerMode, error) {
+	ok, err := s.IsInitialized()
+	if err != nil {
+		return "", fmt.Errorf("failed to check if server is initialized: %w", err)
+	}
+	if !ok {
+		return "", fmt.Errorf("server is not initialized")
+	}
+	c, err := s.configService.GetConfig()
+	if err != nil {
+		return "", fmt.Errorf("failed to get server config: %w", err)
+	}
+	return c.Mode, nil
+}
+
 func (s *Server) Init(mode model.ServerMode) error {
 	if err := s.configService.Init(mode); err != nil {
 		return fmt.Errorf("failed to initialize server config in %s mode: %w", mode, err)

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -101,7 +101,7 @@ func requireInitialized(configService *config.ServerConfigService) gin.HandlerFu
 	return func(c *gin.Context) {
 		cfg, err := configService.GetConfig()
 		if err != nil || !cfg.Initialized {
-			c.AbortWithStatusJSON(http.StatusServiceUnavailable, gin.H{"error": "server not initialized"})
+			c.AbortWithStatusJSON(http.StatusForbidden, gin.H{"error": "server not initialized"})
 			return
 		}
 		c.Next()

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -5,8 +5,8 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mark3labs/mcp-go/server"
 	"github.com/mcpjungle/mcpjungle/internal/model"
-	"github.com/mcpjungle/mcpjungle/internal/service"
 	"github.com/mcpjungle/mcpjungle/internal/service/config"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
 )
 
 const V0PathPrefix = "/api/v0"
@@ -17,13 +17,13 @@ type Server struct {
 	router *gin.Engine
 
 	mcpProxyServer *server.MCPServer
-	mcpService     *service.MCPService
+	mcpService     *mcp.MCPService
 
 	configService *config.ServerConfigService
 }
 
 // NewServer initializes a new Gin server for MCPJungle registry and MCP proxy
-func NewServer(port string, mcpProxyServer *server.MCPServer, mcpService *service.MCPService, configService *config.ServerConfigService) (*Server, error) {
+func NewServer(port string, mcpProxyServer *server.MCPServer, mcpService *mcp.MCPService, configService *config.ServerConfigService) (*Server, error) {
 	r, err := newRouter(mcpProxyServer, mcpService, configService)
 	if err != nil {
 		return nil, err
@@ -54,7 +54,7 @@ func (s *Server) Start() error {
 }
 
 // newRouter sets up the Gin router with the MCP proxy server and API endpoints.
-func newRouter(mcpProxyServer *server.MCPServer, mcpService *service.MCPService, configService *config.ServerConfigService) (*gin.Engine, error) {
+func newRouter(mcpProxyServer *server.MCPServer, mcpService *mcp.MCPService, configService *config.ServerConfigService) (*gin.Engine, error) {
 	r := gin.Default()
 
 	r.GET(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -103,6 +103,7 @@ func requireInitialized(configService *config.ServerConfigService) gin.HandlerFu
 
 // newRouter sets up the Gin router with the MCP proxy server and API endpoints.
 func newRouter(opts *ServerOptions) (*gin.Engine, error) {
+	gin.SetMode(gin.ReleaseMode)
 	r := gin.Default()
 
 	r.GET(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -4,21 +4,27 @@ import (
 	"fmt"
 	"github.com/gin-gonic/gin"
 	"github.com/mark3labs/mcp-go/server"
+	"github.com/mcpjungle/mcpjungle/internal/model"
 	"github.com/mcpjungle/mcpjungle/internal/service"
+	"github.com/mcpjungle/mcpjungle/internal/service/config"
 )
 
 const V0PathPrefix = "/api/v0"
 
+// Server represents the MCPJungle registry server that handles MCP proxy and API requests
 type Server struct {
-	port           string
-	router         *gin.Engine
+	port   string
+	router *gin.Engine
+
 	mcpProxyServer *server.MCPServer
 	mcpService     *service.MCPService
+
+	configService *config.ServerConfigService
 }
 
 // NewServer initializes a new Gin server for MCPJungle registry and MCP proxy
-func NewServer(port string, mcpProxyServer *server.MCPServer, mcpService *service.MCPService) (*Server, error) {
-	r, err := newRouter(mcpProxyServer, mcpService)
+func NewServer(port string, mcpProxyServer *server.MCPServer, mcpService *service.MCPService, configService *config.ServerConfigService) (*Server, error) {
+	r, err := newRouter(mcpProxyServer, mcpService, configService)
 	if err != nil {
 		return nil, err
 	}
@@ -27,8 +33,16 @@ func NewServer(port string, mcpProxyServer *server.MCPServer, mcpService *servic
 		router:         r,
 		mcpProxyServer: mcpProxyServer,
 		mcpService:     mcpService,
+		configService:  configService,
 	}
 	return s, nil
+}
+
+func (s *Server) Init(mode model.ServerMode) error {
+	if err := s.configService.Init(mode); err != nil {
+		return fmt.Errorf("failed to initialize server config in %s mode: %w", mode, err)
+	}
+	return nil
 }
 
 // Start runs the Gin server (blocking call)
@@ -40,7 +54,7 @@ func (s *Server) Start() error {
 }
 
 // newRouter sets up the Gin router with the MCP proxy server and API endpoints.
-func newRouter(mcpProxyServer *server.MCPServer, mcpService *service.MCPService) (*gin.Engine, error) {
+func newRouter(mcpProxyServer *server.MCPServer, mcpService *service.MCPService, configService *config.ServerConfigService) (*gin.Engine, error) {
 	r := gin.Default()
 
 	r.GET(
@@ -49,6 +63,8 @@ func newRouter(mcpProxyServer *server.MCPServer, mcpService *service.MCPService)
 			c.JSON(200, gin.H{"status": "ok"})
 		},
 	)
+
+	r.POST("/init", registerInitServerHandler(configService))
 
 	// Set up the MCP proxy server on /mcp
 	streamableHttpServer := server.NewStreamableHTTPServer(mcpProxyServer)

--- a/internal/api/server_config.go
+++ b/internal/api/server_config.go
@@ -1,0 +1,24 @@
+package api
+
+import (
+	"github.com/gin-gonic/gin"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/internal/service/config"
+)
+
+func registerInitServerHandler(configService *config.ServerConfigService) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req struct {
+			Mode string `json:"mode" binding:"required,oneof=development production"`
+		}
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(400, gin.H{"error": "Invalid request body: " + err.Error()})
+			return
+		}
+		if err := configService.Init(model.ServerMode(req.Mode)); err != nil {
+			c.JSON(500, gin.H{"error": "Failed to initialize server: " + err.Error()})
+			return
+		}
+		c.JSON(200, gin.H{"status": "Server initialized successfully", "mode": req.Mode})
+	}
+}

--- a/internal/api/server_config.go
+++ b/internal/api/server_config.go
@@ -4,21 +4,46 @@ import (
 	"github.com/gin-gonic/gin"
 	"github.com/mcpjungle/mcpjungle/internal/model"
 	"github.com/mcpjungle/mcpjungle/internal/service/config"
+	"github.com/mcpjungle/mcpjungle/internal/service/user"
 )
 
-func registerInitServerHandler(configService *config.ServerConfigService) gin.HandlerFunc {
+func registerInitServerHandler(configService *config.ServerConfigService, userService *user.UserService) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		var req struct {
-			Mode string `json:"mode" binding:"required,oneof=development production"`
+			Mode model.ServerMode `json:"mode" binding:"required,oneof=development production"`
 		}
 		if err := c.ShouldBindJSON(&req); err != nil {
 			c.JSON(400, gin.H{"error": "Invalid request body: " + err.Error()})
 			return
 		}
-		if err := configService.Init(model.ServerMode(req.Mode)); err != nil {
+		ok, err := configService.Init(req.Mode)
+		if err != nil {
 			c.JSON(500, gin.H{"error": "Failed to initialize server: " + err.Error()})
 			return
 		}
-		c.JSON(200, gin.H{"status": "Server initialized successfully", "mode": req.Mode})
+		if !ok {
+			c.JSON(400, gin.H{"status": "Server already initialized", "mode": req.Mode})
+			return
+		}
+		if req.Mode != model.ModeProd {
+			// If the server was successfully initialized and the mode is dev,
+			// return a success message without creating an admin user
+			c.JSON(200, gin.H{"status": "Server initialized successfully in development mode"})
+			return
+		}
+		// If the server was successfully initialized and the mode is prod,
+		// create an admin user and return its access token
+		admin, err := userService.CreateAdminUser()
+		if err != nil {
+			c.JSON(
+				500, gin.H{"error": "Initialization succeeded but failed to create admin user: " + err.Error()},
+			)
+			return
+		}
+		payload := gin.H{
+			"status":             "Server initialized successfully",
+			"admin_access_token": admin.AccessToken,
+		}
+		c.JSON(200, payload)
 	}
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -2,6 +2,7 @@ package db
 
 import (
 	"fmt"
+	"gorm.io/gorm/logger"
 	"log"
 
 	"github.com/glebarez/sqlite"
@@ -23,7 +24,10 @@ func NewDBConnection(dsn string) (*gorm.DB, error) {
 		dialector = postgres.Open(dsn)
 	}
 
-	db, err := gorm.Open(dialector, &gorm.Config{})
+	c := &gorm.Config{
+		Logger: logger.Default.LogMode(logger.Silent),
+	}
+	db, err := gorm.Open(dialector, c)
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to database: %w", err)
 	}

--- a/internal/migrations/migration.go
+++ b/internal/migrations/migration.go
@@ -14,5 +14,8 @@ func Migrate(db *gorm.DB) error {
 	if err := db.AutoMigrate(&model.Tool{}); err != nil {
 		return fmt.Errorf("auto‑migration failed for Tool model: %v", err)
 	}
+	if err := db.AutoMigrate(&model.ServerConfig{}); err != nil {
+		return fmt.Errorf("auto‑migration failed for ServerConfig model: %v", err)
+	}
 	return nil
 }

--- a/internal/migrations/migration.go
+++ b/internal/migrations/migration.go
@@ -17,5 +17,8 @@ func Migrate(db *gorm.DB) error {
 	if err := db.AutoMigrate(&model.ServerConfig{}); err != nil {
 		return fmt.Errorf("auto‑migration failed for ServerConfig model: %v", err)
 	}
+	if err := db.AutoMigrate(&model.User{}); err != nil {
+		return fmt.Errorf("auto‑migration failed for User model: %v", err)
+	}
 	return nil
 }

--- a/internal/model/server_config.go
+++ b/internal/model/server_config.go
@@ -1,0 +1,32 @@
+package model
+
+import (
+	"fmt"
+	"gorm.io/gorm"
+)
+
+type ServerMode string
+
+const (
+	ModeDev  ServerMode = "development"
+	ModeProd ServerMode = "production"
+)
+
+// ServerConfig represents the configuration for the MCPJungle server.
+type ServerConfig struct {
+	gorm.Model
+
+	Mode ServerMode `gorm:"type:varchar(12);not null"`
+
+	// Initialized indicates whether the server has been initialized.
+	// If this is set to false, the server is not yet ready for use and all requests to it will be rejected.
+	Initialized bool `gorm:"not null;default:false"`
+}
+
+func (c *ServerConfig) BeforeSave(tx *gorm.DB) (err error) {
+	// Make sure that the server mode is valid before saving
+	if c.Mode != ModeDev && c.Mode != ModeProd {
+		return fmt.Errorf("invalid server mode: %s", c.Mode)
+	}
+	return nil
+}

--- a/internal/model/server_config.go
+++ b/internal/model/server_config.go
@@ -23,7 +23,7 @@ type ServerConfig struct {
 	Mode ServerMode `gorm:"type:varchar(12);not null"`
 
 	// Initialized indicates whether the server has been initialized.
-	// If this is set to false, the server is not yet ready for use and all requests to it will be rejected.
+	// If this is set to false, the server is not yet ready for use and all requests to it should be rejected.
 	Initialized bool `gorm:"not null;default:false"`
 }
 

--- a/internal/model/server_config.go
+++ b/internal/model/server_config.go
@@ -8,7 +8,11 @@ import (
 type ServerMode string
 
 const (
-	ModeDev  ServerMode = "development"
+	// ModeDev is ideal for individual developers running the server locally for
+	// their personal MCP clients like Claude, Cursor, etc. and small use cases.
+	ModeDev ServerMode = "development"
+
+	// ModeProd is ideal for production (enterprise) deployments
 	ModeProd ServerMode = "production"
 )
 

--- a/internal/model/user.go
+++ b/internal/model/user.go
@@ -1,0 +1,17 @@
+package model
+
+import "gorm.io/gorm"
+
+// UserRole represents the role of a user in the MCPJungle system.
+type UserRole string
+
+const UserRoleAdmin UserRole = "admin"
+
+// User represents a user in the MCPJungle system
+type User struct {
+	gorm.Model
+
+	Username    string   `json:"username" gorm:"unique; not null"`
+	Role        UserRole `json:"role" gorm:"not null"`
+	AccessToken string   `json:"access_token" gorm:"unique; not null"`
+}

--- a/internal/service/config/server_config.go
+++ b/internal/service/config/server_config.go
@@ -7,6 +7,7 @@ import (
 	"gorm.io/gorm"
 )
 
+// ServerConfigService provides methods to manage server configuration in the database.
 type ServerConfigService struct {
 	db *gorm.DB
 }
@@ -15,6 +16,8 @@ func NewServerConfigService(db *gorm.DB) *ServerConfigService {
 	return &ServerConfigService{db: db}
 }
 
+// GetConfig retrieves the server configuration from the database.
+// If no configuration exists, it returns a default uninitialized config.
 func (s *ServerConfigService) GetConfig() (model.ServerConfig, error) {
 	var config model.ServerConfig
 	err := s.db.First(&config).Error

--- a/internal/service/config/server_config.go
+++ b/internal/service/config/server_config.go
@@ -36,6 +36,7 @@ func (s *ServerConfigService) Init(mode model.ServerMode) error {
 		return err
 	}
 	if config.Initialized {
+		// TODO: Instead of NOOP, return a specific error indicating that the server is already initialized
 		// Config already exists, do nothing
 		return nil
 	}

--- a/internal/service/config/server_config.go
+++ b/internal/service/config/server_config.go
@@ -1,0 +1,35 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"gorm.io/gorm"
+)
+
+type ServerConfigService struct {
+	db *gorm.DB
+}
+
+func NewServerConfigService(db *gorm.DB) *ServerConfigService {
+	return &ServerConfigService{db: db}
+}
+
+func (s *ServerConfigService) Init(mode model.ServerMode) error {
+	var config model.ServerConfig
+	err := s.db.First(&config).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		// No config exists, create one
+		config = model.ServerConfig{
+			Mode:        mode,
+			Initialized: true,
+		}
+		return s.db.Create(&config).Error
+	}
+	// If any other error, return it
+	if err != nil {
+		return fmt.Errorf("failed to fetch server configuration from db: %v", err)
+	}
+	// Config already exists, do nothing
+	return nil
+}

--- a/internal/service/config/server_config.go
+++ b/internal/service/config/server_config.go
@@ -30,20 +30,22 @@ func (s *ServerConfigService) GetConfig() (model.ServerConfig, error) {
 	return config, nil
 }
 
-func (s *ServerConfigService) Init(mode model.ServerMode) error {
+// Init initializes the server configuration in the database.
+// It is an idempotent operation. It returns true if the config was created.
+// If the config already exists, it returns false and does nothing else.
+func (s *ServerConfigService) Init(mode model.ServerMode) (bool, error) {
 	config, err := s.GetConfig()
 	if err != nil {
-		return err
+		return false, err
 	}
 	if config.Initialized {
-		// TODO: Instead of NOOP, return a specific error indicating that the server is already initialized
 		// Config already exists, do nothing
-		return nil
+		return false, nil
 	}
 	// No config exists, create one
 	config = model.ServerConfig{
 		Mode:        mode,
 		Initialized: true,
 	}
-	return s.db.Create(&config).Error
+	return true, s.db.Create(&config).Error
 }

--- a/internal/service/mcp/mcp.go
+++ b/internal/service/mcp/mcp.go
@@ -1,4 +1,4 @@
-package service
+package mcp
 
 import (
 	"fmt"

--- a/internal/service/mcp/proxy.go
+++ b/internal/service/mcp/proxy.go
@@ -1,4 +1,4 @@
-package service
+package mcp
 
 import (
 	"context"

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -1,4 +1,4 @@
-package service
+package mcp
 
 import (
 	"context"

--- a/internal/service/mcp/tool.go
+++ b/internal/service/mcp/tool.go
@@ -1,4 +1,4 @@
-package service
+package mcp
 
 import (
 	"context"

--- a/internal/service/mcp/util.go
+++ b/internal/service/mcp/util.go
@@ -1,4 +1,4 @@
-package service
+package mcp
 
 import (
 	"context"

--- a/internal/service/mcp/util_test.go
+++ b/internal/service/mcp/util_test.go
@@ -1,4 +1,4 @@
-package service
+package mcp
 
 import (
 	"testing"

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -1,0 +1,45 @@
+package user
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"fmt"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"gorm.io/gorm"
+)
+
+// UserService provides methods to manage users in the MCPJungle system.
+type UserService struct {
+	db *gorm.DB
+}
+
+func NewUserService(db *gorm.DB) *UserService {
+	return &UserService{db: db}
+}
+
+// CreateAdminUser creates an admin user in the MCPJungle system.
+func (u *UserService) CreateAdminUser() (*model.User, error) {
+	token, err := generateAccessToken()
+	if err != nil {
+		return nil, err
+	}
+	user := model.User{
+		Username:    "admin",
+		Role:        model.UserRoleAdmin,
+		AccessToken: token,
+	}
+	if err := u.db.Create(&user).Error; err != nil {
+		return nil, fmt.Errorf("failed to create admin user: %w", err)
+	}
+	return &user, nil
+}
+
+// generateAccessToken generates a 256-bit secure random access token for user authentication.
+func generateAccessToken() (string, error) {
+	const tokenLength = 32
+	b := make([]byte, tokenLength)
+	if _, err := rand.Read(b); err != nil {
+		return "", fmt.Errorf("failed to generate access token: %v", err)
+	}
+	return base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(b), nil
+}


### PR DESCRIPTION
This PR introduces the following new concepts:

1. Modes
Mcpjungle server can now run in 2 modes.
- The default is `development` (when you run `mcpjungle start`). This mode is ideal for individuals mainly running the server on their local machines for their mcp clients (Claude, Cursor, personal agents, etc) and don't have high security requirements.
- Alternatively, you can use `mcpjungle start --prod` to run the server in `production` mode. This is ideal for enterprise use cases where you would deploy the server in your Datacenter or a remote host machine to support multiple mcp clients / ai agents.

2. User authentication & authorization
In production mode, you must initialize the server using `mcpjungle init-server`. This will create an admin user in the server and store its API access token in your home directory (`~/.mcpjungle.conf`). You can then use the mcpjungle cli to make authenticated requests to the server API.

---

As a next step, I'll be working on building ACLs for the MCP proxy server. You'll be able to control which of your MCP clients are able to view and call which MCP servers and tools.

---

NOTE: mcpjungle is completely FREE. No aspect of it requires any payment.