### PR TITLE
feat: cgoenabled go releaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -3,6 +3,9 @@
 
 version: 2
 
+# Basename for the build artifacts, used in the archive names and Docker images.
+project_name: mcpjungle
+
 before:
   hooks:
     - go test -v ./...
@@ -21,6 +24,22 @@ builds:
       - arm64
     ldflags:
       - -s -w -X github.com/mcpjungle/mcpjungle/cmd.Version={{.Version}}
+    env:
+      - CGO_ENABLED=0
+      - GOWORK=off
+    overrides:
+      # macOS builds - use CGO for better compatibility
+      # overrides for darwin builds to enable CGO
+      - goos: darwin
+        goarch: amd64
+        env:
+          - CGO_ENABLED=1
+          - GOWORK=off
+      - goos: darwin
+        goarch: arm64
+        env:
+          - CGO_ENABLED=1
+          - GOWORK=off
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
to build the app differently for macOS and for Linux/Windows

On macOS →  Turn CGO on. This lets  Go code use some C code under the hood, which helps it work better with macOS features (like system security or file handling). 
Example: If you use the macOS Keychain for storing secrets, CGO helps you access it smoothly.

On Linux/Windows → Turn CGO off. This makes the app into a fully self-contained binary, therefore no extra libraries needed. You can drop it in a Docker container or send it to another server and it will just work. 
Example: You can copy the binary into a minimal alpine container and it will run without installing extra packages.

All builds are consistent by turning off Go’s workspace mode (GOWORK=off) and itsupport both Intel (AMD64) and ARM (ARM64) chips.

```bash
$ goreleaser build --snapshot --clean
```

VERIFICATION:
```bash
artifacts.json
config.yaml
mcpjungle_darwin_amd64_v1
mcpjungle_darwin_arm64_v8.0
mcpjungle_linux_amd64_v1
mcpjungle_linux_arm64_v8.0
mcpjungle_windows_amd64_v1
mcpjungle_windows_arm64_v8.0
metadata.json

--- ARM64 Binary Verification ---
dist/mcpjungle_linux_arm64_v8.0/mcpjungle: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=54225cbc057b3121707296061b075cb2eab00a5a, stripped
````

Future: anytime if the build are going to process in a github runner, darwin build need a mac-os environments