### PR TITLE
fix: resolve docker-compose startup timing issues

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+    restart: unless-stopped
 
   pgadmin:
     image: dpage/pgadmin4:latest
@@ -36,7 +37,8 @@ services:
     ports:
       - "8080:8080"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     restart: always
 
 volumes:


### PR DESCRIPTION
Issue:

- Database container starts → Application container starts immediately
- Application tries to connect → PostgreSQL not ready → Connection refused
- Application retries → Eventually succeeds after multiple attempts

Fix:

- Database container starts → Health check runs → PostgreSQL becomes healthy
- Application waits for healthy status → Starts only when database is ready
- Application connects successfully on first attempt