### PR TITLE
fix: restrict /metrics endpoint to admin users in production

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -132,7 +132,7 @@ func (s *Server) setupRouter() (*gin.Engine, error) {
 		r.Use(otelgin.Middleware(s.otelProviders.ServiceName()))
 
 		// expose prometheus metrics endpoint - admin access only in production mode
-		r.GET("/metrics", s.requireInitialized(), s.verifyUserAuthForAPIAccess(), s.requireAdminUser(), gin.WrapH(promhttp.Handler()))
+		r.GET("/metrics", s.requireInitialized(), s.requireAdminUser(), gin.WrapH(promhttp.Handler()))
 	}
 
 	r.GET(

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -131,8 +131,8 @@ func (s *Server) setupRouter() (*gin.Engine, error) {
 		// instrument gin
 		r.Use(otelgin.Middleware(s.otelProviders.ServiceName()))
 
-		// expose prometheus metrics endpoint
-		r.GET("/metrics", gin.WrapH(promhttp.Handler()))
+		// expose prometheus metrics endpoint - admin access only in production mode
+		r.GET("/metrics", s.requireInitialized(), s.verifyUserAuthForAPIAccess(), s.requireAdminUser(), gin.WrapH(promhttp.Handler()))
 	}
 
 	r.GET(


### PR DESCRIPTION
Fixes #92

Added `requireAdminUser()` middleware to `/metrics` endpoint as requested in the issue.