### PR TITLE
fix: file system running in docker

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -156,10 +156,54 @@ docker-compose up -d
 goreleaser build --single-target --clean --snapshot
 ```
 
-## Contributing Guidelines
+## Docker Filesystem Access
 
-For detailed contribution guidelines, see [CONTRIBUTION.md](./CONTRIBUTION.md).
+When running MCPJungle in Docker, the filesystem MCP server needs special configuration to access the host machine's filesystem. The Docker Compose files have been updated to mount the host filesystem at `/host` inside the container.
 
+### Key Points for Docker Filesystem Access
+
+1. **Volume Mount**: The host filesystem is mounted as read-only at `/host` inside the container
+2. **Filesystem MCP Configuration**: Use `/host` as the root path when configuring the filesystem MCP server
+3. **Security**: The mount is read-only by default for security. Modify the volume mount in `docker-compose.yaml` if you need write access
+
+### Example Filesystem MCP Configuration for Docker
+
+```json
+{
+  "name": "filesystem",
+  "transport": "stdio",
+  "description": "filesystem mcp server",
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/host"]
+}
+```
+
+> **Tip**: Copy the JSON configuration above and save it to a file (e.g., `filesystem.json`) to use with the `mcpjungle register -c` command.
+
+### Alternative: Mount Specific Directories for Better Security
+
+Instead of mounting the entire filesystem, you can mount specific directories by modifying the volume mounts in `docker-compose.yaml`:
+
+```yaml
+volumes:
+  # Mount only your home directory
+  - ${HOME}:/host/home:ro
+  # Mount a specific project directory
+  - /path/to/your/project:/host/project:ro
+  # Mount temp directory with write access
+  - /tmp:/host/tmp:rw
+```
+
+Then configure your filesystem MCP server accordingly:
+```json
+{
+  "name": "filesystem",
+  "transport": "stdio", 
+  "description": "filesystem mcp server",
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/host/home"]
+}
+```
 
 ## Troubleshooting
 
@@ -168,12 +212,17 @@ For detailed contribution guidelines, see [CONTRIBUTION.md](./CONTRIBUTION.md).
 1. **Build failures**: Ensure you have the correct Go version and dependencies
 2. **Database connection issues**: Check if PostgreSQL/SQLite is running and accessible
 3. **MCP server registration failures**: Verify the MCP server is running and accessible
+4. **Docker filesystem access issues**: Ensure the host filesystem is properly mounted at `/host`
 
 ### Getting Help
 
 - Check existing [issues](https://github.com/mcpjungle/MCPJungle/issues)
 - Join our [Discord community](https://discord.gg/CapV4Z3krk)
 - Open a Discussion for questions and proposals
+
+## Contributing Guidelines
+
+For detailed contribution guidelines, see [CONTRIBUTION.md](./CONTRIBUTION.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ mcpjungle start
 This starts the main registry server and MCP gateway, accessible on port `8080` by default.
 
 
+
 ### Database
 The mcpjungle server relies on a database and by default, creates a SQLite DB in the current working directory.
 
@@ -298,6 +299,8 @@ The config file format for registering a Streamable HTTP-based MCP server is:
 ### Registering STDIO-based servers
 
 Here's an example configuration file (let's call it `filesystem.json`) for a MCP server that uses the STDIO transport:
+
+**When running MCPJungle directly on the host machine:**
 ```json
 {
   "name": "filesystem",
@@ -308,8 +311,23 @@ Here's an example configuration file (let's call it `filesystem.json`) for a MCP
 }
 ```
 
+**For Docker deployment:**
+```json
+{
+  "name": "filesystem",
+  "transport": "stdio",
+  "description": "filesystem mcp server",
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-filesystem", "/host"]
+}
+```
+
+> [!NOTE]
+> When running MCPJungle in Docker, use `/host` as the root path to access the host filesystem. See [DEVELOPMENT.md](./DEVELOPMENT.md#docker-filesystem-access) for detailed Docker configuration.
+
 You can register this MCP server in MCPJungle by providing the configuration file:
 ```bash
+# Save the JSON configuration to a file (e.g., filesystem.json)
 mcpjungle register -c ./filesystem.json
 ```
 

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -40,6 +40,15 @@ services:
       OTEL_ENABLED: ${OTEL_ENABLED:-true}
     ports:
       - "8080:8080"
+    # volumes:
+      # Uncomment the following lines ONLY if you need filesystem MCP server access
+      # WARNING: This mounts the host filesystem and should only be used for personal/development use
+      # Production deployments should avoid mounting host filesystem for security reasons
+      # - /:/host:ro
+      # 
+      # Alternative: Mount specific directories for better security
+      # - ${HOME}:/host/home:ro
+      # - /tmp:/host/tmp:rw
     depends_on:
       db:
         condition: service_healthy

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -29,6 +29,12 @@ services:
       OTEL_ENABLED: ${OTEL_ENABLED:-false}
     ports:
       - "8080:8080"
+    volumes:
+      # Mount host filesystem to enable filesystem MCP server access
+      - /:/host:ro
+      # Optional: Mount specific directories for better security
+      # - ${HOME}:/host/home:ro
+      # - /tmp:/host/tmp:rw
     depends_on:
       db:
         condition: service_healthy

--- a/scripts/test-mcpjungle.sh
+++ b/scripts/test-mcpjungle.sh
@@ -135,9 +135,15 @@ BIN_SERVER_PID=$!
 log "Waiting for local binary server health"
 wait_for_health "http://127.0.0.1:9090/health"
 
-log "All tests passed 🎉"
- 
-# 7) Print Homebrew formula config snippet
+# 7) Test filesystem MCP server in Docker
+log "Testing filesystem MCP server in Docker"
+"$BIN_PATH" --registry "$REGISTRY_URL" init-server
+"$BIN_PATH" --registry "$REGISTRY_URL" register --name filesystem --transport stdio --command npx --args "-y,@modelcontextprotocol/server-filesystem,/host"
+"$BIN_PATH" --registry "$REGISTRY_URL" invoke filesystem__list_allowed_directories --input '{}' >/dev/null
+
+# 8) Print Homebrew formula config snippet
 log "Homebrew formula config (from .goreleaser.yaml)"
 sed -n '/^brews:/,/^dockers:/p' "$ROOT_DIR/.goreleaser.yaml" || true
 popd >/dev/null
+
+log "All tests passed 🎉"


### PR DESCRIPTION
ISSUE: #98 
The issue was that when MCPJungle runs inside a Docker container, the filesystem MCP server could only access files within the container, not the host machine's filesystem.

It uses `npx @modelcontextprotocol/server-filesystem .` runs with the container's working directory, which is typically / or the container's root. This means it can only access files within the container, not the host machine's filesystem. 

Why?
The `client.NewStdioMCPClient()` function from the `mcp-go` library doesn't provide a way to specify the working directory for the subprocess, so it inherits the working directory of the parent MCPJungle process.

So if we modify the docker config to mount the host fs into the container and update the MCP server fs config to use the mounted path, this should fix this.

- Added volume mounts to both `docker-compose.yaml` and `docker-compose-prod.yaml` to mount the host filesystem at `/host` inside the container.
- Added readme + develoment instruction for docker filesystem
- Instead of storing `filesystem.json` in `examples/` directory, we could simply use in `README` and `DEVELOPMENT`, users can copy paste and use directly as they are very simple and reduces maintenance, fewer files to manage too