### PR TITLE
Feature/rename sqlite db file 129

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ dist/
 # Local dev
 mcpjungle
 mcp.db
+mcpjungle.db

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -76,13 +76,15 @@ golangci-lint run --fix
 When running MCPJungle with SQLite, you can access the database using the `sqlite3` command line tool:
 
 ```bash
-sqlite3 mcp.db
+sqlite3 mcpjungle.db
 
 > .tables
 > SELECT * FROM mcp_servers;
 > SELECT * FROM tools;
 # and so on...
 ```
+
+**Note:** For backward compatibility, MCPJungle will still use existing `mcp.db` files if they exist, but will create new databases as `mcpjungle.db`.
 
 #### PostgreSQL Development
 When running MCPJungle with docker-compose, you can access the PostgreSQL database using the `pgadmin` utility:

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -16,26 +16,26 @@ import (
 // Only one database connection should be created and used throughout the application.
 
 const (
-	newDBFile = "mcpjungle.db"
-	oldDBFile = "mcp.db"
+	dbFilename           = "mcpjungle.db"
+	deprecatedDbFilename = "mcp.db"
 )
 
 // getSQLiteDBPath determines which SQLite database file to use.
 // It prioritizes the new mcpjungle.db file, but falls back to the old mcp.db file for backward compatibility.
 func getSQLiteDBPath() string {
 	// Check if the new database file exists
-	if _, err := os.Stat(newDBFile); err == nil {
-		return newDBFile
+	if _, err := os.Stat(dbFilename); err == nil {
+		return dbFilename
 	}
 	
 	// Check if the old database file exists (backward compatibility)
-	if _, err := os.Stat(oldDBFile); err == nil {
-		log.Printf("[db] WARNING: Using deprecated database file '%s'. Please consider renaming it to '%s' for future compatibility.", oldDBFile, newDBFile)
-		return oldDBFile
+	if _, err := os.Stat(deprecatedDbFilename); err == nil {
+		log.Printf("[db] WARNING: Using deprecated database file '%s'. Please consider renaming it to '%s' for future compatibility.", deprecatedDbFilename, dbFilename)
+		return deprecatedDbFilename
 	}
 	
 	// Neither exists, use the new file name
-	return newDBFile
+	return dbFilename
 }
 
 // NewDBConnection creates a new database connection based on the provided DSN.

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -4,6 +4,7 @@ package db
 import (
 	"fmt"
 	"log"
+	"os"
 
 	"github.com/glebarez/sqlite"
 	"gorm.io/driver/postgres"
@@ -14,13 +15,39 @@ import (
 // TODO: Turn this into a singleton class.
 // Only one database connection should be created and used throughout the application.
 
+const (
+	newDBFile = "mcpjungle.db"
+	oldDBFile = "mcp.db"
+)
+
+// getSQLiteDBPath determines which SQLite database file to use.
+// It prioritizes the new mcpjungle.db file, but falls back to the old mcp.db file for backward compatibility.
+func getSQLiteDBPath() string {
+	// Check if the new database file exists
+	if _, err := os.Stat(newDBFile); err == nil {
+		return newDBFile
+	}
+	
+	// Check if the old database file exists (backward compatibility)
+	if _, err := os.Stat(oldDBFile); err == nil {
+		log.Printf("[db] WARNING: Using deprecated database file '%s'. Please consider renaming it to '%s' for future compatibility.", oldDBFile, newDBFile)
+		return oldDBFile
+	}
+	
+	// Neither exists, use the new file name
+	return newDBFile
+}
+
 // NewDBConnection creates a new database connection based on the provided DSN.
-// If the DSN is empty, it falls back to an embedded SQLite database at "./mcp.db".
+// If the DSN is empty, it falls back to an embedded SQLite database.
+// For backward compatibility, it will use an existing "mcp.db" file if present,
+// otherwise it creates/uses "mcpjungle.db".
 func NewDBConnection(dsn string) (*gorm.DB, error) {
 	var dialector gorm.Dialector
 	if dsn == "" {
-		log.Println("[db] DATABASE_URL not set – falling back to embedded SQLite ./mcp.db")
-		dialector = sqlite.Open("mcp.db?_busy_timeout=5000&_journal_mode=WAL")
+		dbPath := getSQLiteDBPath()
+		log.Printf("[db] DATABASE_URL not set – falling back to embedded SQLite ./%s", dbPath)
+		dialector = sqlite.Open(fmt.Sprintf("%s?_busy_timeout=5000&_journal_mode=WAL", dbPath))
 	} else {
 		dialector = postgres.Open(dsn)
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	dbFilename           = "mcpjungle.db"
-	deprecatedDbFilename = "mcp.db"
+	deprecatedDBFilename = "mcp.db"
 )
 
 // getSQLiteDBPath determines which SQLite database file to use.
@@ -27,13 +27,13 @@ func getSQLiteDBPath() string {
 	if _, err := os.Stat(dbFilename); err == nil {
 		return dbFilename
 	}
-	
+
 	// Check if the old database file exists (backward compatibility)
-	if _, err := os.Stat(deprecatedDbFilename); err == nil {
-		log.Printf("[db] WARNING: Using deprecated database file '%s'. Please consider renaming it to '%s' for future compatibility.", deprecatedDbFilename, dbFilename)
-		return deprecatedDbFilename
+	if _, err := os.Stat(deprecatedDBFilename); err == nil {
+		log.Printf("[db] WARNING: Using deprecated database file '%s'. Please consider renaming it to '%s' for future compatibility.", deprecatedDBFilename, dbFilename)
+		return deprecatedDBFilename
 	}
-	
+
 	// Neither exists, use the new file name
 	return dbFilename
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -8,6 +8,36 @@ import (
 	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
 )
 
+// cleanupDBFiles removes both old and new database files and their associated WAL and SHM files
+func cleanupDBFiles(t *testing.T) {
+	dbFiles := []string{"mcp.db", "mcpjungle.db"}
+	extensions := []string{"", "-wal", "-shm"}
+	
+	for _, dbFile := range dbFiles {
+		for _, ext := range extensions {
+			file := dbFile + ext
+			if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
+				t.Logf("Failed to clean up %s: %v", file, err)
+			}
+		}
+	}
+}
+
+// cleanupDBFilesBenchmark is the same as cleanupDBFiles but for benchmark tests
+func cleanupDBFilesBenchmark(b *testing.B) {
+	dbFiles := []string{"mcp.db", "mcpjungle.db"}
+	extensions := []string{"", "-wal", "-shm"}
+	
+	for _, dbFile := range dbFiles {
+		for _, ext := range extensions {
+			file := dbFile + ext
+			if err := os.Remove(file); err != nil && !os.IsNotExist(err) {
+				b.Logf("Failed to clean up %s: %v", file, err)
+			}
+		}
+	}
+}
+
 func TestNewDBConnection(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -20,16 +50,7 @@ func TestNewDBConnection(t *testing.T) {
 			dsn:         "",
 			expectError: false,
 			cleanup: func() {
-				// Clean up SQLite database file
-				if err := os.Remove("mcp.db"); err != nil && !os.IsNotExist(err) {
-					t.Logf("Failed to clean up mcp.db: %v", err)
-				}
-				if err := os.Remove("mcp.db-wal"); err != nil && !os.IsNotExist(err) {
-					t.Logf("Failed to clean up mcp.db-wal: %v", err)
-				}
-				if err := os.Remove("mcp.db-shm"); err != nil && !os.IsNotExist(err) {
-					t.Logf("Failed to clean up mcp.db-shm: %v", err)
-				}
+				cleanupDBFiles(t)
 			},
 		},
 		{
@@ -83,17 +104,9 @@ func TestNewDBConnection(t *testing.T) {
 }
 
 func TestNewDBConnection_SQLiteFallback(t *testing.T) {
-	// Ensure no existing database file
+	// Ensure no existing database files
 	cleanup := func() {
-		if err := os.Remove("mcp.db"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db: %v", err)
-		}
-		if err := os.Remove("mcp.db-wal"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db-wal: %v", err)
-		}
-		if err := os.Remove("mcp.db-shm"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db-shm: %v", err)
-		}
+		cleanupDBFiles(t)
 	}
 
 	cleanup()
@@ -104,8 +117,8 @@ func TestNewDBConnection_SQLiteFallback(t *testing.T) {
 	testhelpers.AssertNoError(t, err)
 	testhelpers.AssertNotNil(t, db)
 
-	// Verify SQLite database file was created
-	_, err = os.Stat("mcp.db")
+	// Verify SQLite database file was created (should be the new name)
+	_, err = os.Stat("mcpjungle.db")
 	testhelpers.AssertNoError(t, err)
 
 	// Test database operations
@@ -129,15 +142,7 @@ func TestNewDBConnection_SQLiteFallback(t *testing.T) {
 
 func TestNewDBConnection_DatabaseConfiguration(t *testing.T) {
 	cleanup := func() {
-		if err := os.Remove("mcp.db"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db: %v", err)
-		}
-		if err := os.Remove("mcp.db-wal"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db-wal: %v", err)
-		}
-		if err := os.Remove("mcp.db-shm"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db-shm: %v", err)
-		}
+		cleanupDBFiles(t)
 	}
 
 	cleanup()
@@ -168,15 +173,7 @@ func TestNewDBConnection_DatabaseConfiguration(t *testing.T) {
 
 func TestNewDBConnection_ConcurrentAccess(t *testing.T) {
 	cleanup := func() {
-		if err := os.Remove("mcp.db"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db: %v", err)
-		}
-		if err := os.Remove("mcp.db-wal"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db-wal: %v", err)
-		}
-		if err := os.Remove("mcp.db-shm"); err != nil && !os.IsNotExist(err) {
-			t.Logf("Failed to clean up mcp.db-shm: %v", err)
-		}
+		cleanupDBFiles(t)
 	}
 
 	cleanup()
@@ -233,7 +230,7 @@ func TestNewDBConnection_WithCustomPath(t *testing.T) {
 	testhelpers.AssertNotNil(t, db)
 
 	// Verify database file was created in temp directory
-	dbPath := filepath.Join(tempDir, "mcp.db")
+	dbPath := filepath.Join(tempDir, "mcpjungle.db")
 	_, err = os.Stat(dbPath)
 	testhelpers.AssertNoError(t, err)
 
@@ -288,15 +285,7 @@ func TestNewDBConnection_ErrorHandling(t *testing.T) {
 // Benchmark tests
 func BenchmarkNewDBConnection_SQLite(b *testing.B) {
 	cleanup := func() {
-		if err := os.Remove("mcp.db"); err != nil && !os.IsNotExist(err) {
-			b.Logf("Failed to clean up mcp.db: %v", err)
-		}
-		if err := os.Remove("mcp.db-wal"); err != nil && !os.IsNotExist(err) {
-			b.Logf("Failed to clean up mcp.db-wal: %v", err)
-		}
-		if err := os.Remove("mcp.db-shm"); err != nil && !os.IsNotExist(err) {
-			b.Logf("Failed to clean up mcp.db-shm: %v", err)
-		}
+		cleanupDBFilesBenchmark(b)
 	}
 
 	cleanup()
@@ -315,5 +304,90 @@ func BenchmarkNewDBConnection_SQLite(b *testing.B) {
 		}
 
 		sqlDB.Close()
+	}
+}
+
+// Test backward compatibility and new database file functionality
+func TestSQLiteDBPath_BackwardCompatibility(t *testing.T) {
+	cleanup := func() {
+		cleanupDBFiles(t)
+	}
+
+	tests := []struct {
+		name           string
+		setup          func()
+		expectedDBFile string
+		expectWarning  bool
+	}{
+		{
+			name:           "no existing files - should create new file",
+			setup:          func() {},
+			expectedDBFile: "mcpjungle.db",
+			expectWarning:  false,
+		},
+		{
+			name: "old file exists - should use old file with warning",
+			setup: func() {
+				oldDB, err := os.Create("mcp.db")
+				testhelpers.AssertNoError(t, err)
+				oldDB.Close()
+			},
+			expectedDBFile: "mcp.db",
+			expectWarning:  true,
+		},
+		{
+			name: "new file exists - should use new file",
+			setup: func() {
+				newDB, err := os.Create("mcpjungle.db")
+				testhelpers.AssertNoError(t, err)
+				newDB.Close()
+			},
+			expectedDBFile: "mcpjungle.db",
+			expectWarning:  false,
+		},
+		{
+			name: "both files exist - should prefer new file",
+			setup: func() {
+				oldDB, err := os.Create("mcp.db")
+				testhelpers.AssertNoError(t, err)
+				oldDB.Close()
+
+				newDB, err := os.Create("mcpjungle.db")
+				testhelpers.AssertNoError(t, err)
+				newDB.Close()
+			},
+			expectedDBFile: "mcpjungle.db",
+			expectWarning:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cleanup() // Clean up before each test
+			tt.setup()
+
+			// Test the path selection logic
+			result := getSQLiteDBPath()
+			testhelpers.AssertEqual(t, tt.expectedDBFile, result)
+
+			// Test that the database connection actually works
+			db, err := NewDBConnection("")
+			testhelpers.AssertNoError(t, err)
+			testhelpers.AssertNotNil(t, db)
+
+			// Verify the expected database file exists
+			_, err = os.Stat(tt.expectedDBFile)
+			testhelpers.AssertNoError(t, err)
+
+			// Test basic functionality
+			sqlDB, err := db.DB()
+			testhelpers.AssertNoError(t, err)
+			err = sqlDB.Ping()
+			testhelpers.AssertNoError(t, err)
+			err = sqlDB.Close()
+			testhelpers.AssertNoError(t, err)
+
+			cleanup() // Clean up after each test
+		})
 	}
 }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -12,7 +12,7 @@ import (
 func cleanupDBFiles(t *testing.T) {
 	dbFiles := []string{"mcp.db", "mcpjungle.db"}
 	extensions := []string{"", "-wal", "-shm"}
-	
+
 	for _, dbFile := range dbFiles {
 		for _, ext := range extensions {
 			file := dbFile + ext
@@ -27,7 +27,7 @@ func cleanupDBFiles(t *testing.T) {
 func cleanupDBFilesBenchmark(b *testing.B) {
 	dbFiles := []string{"mcp.db", "mcpjungle.db"}
 	extensions := []string{"", "-wal", "-shm"}
-	
+
 	for _, dbFile := range dbFiles {
 		for _, ext := range extensions {
 			file := dbFile + ext


### PR DESCRIPTION
Fixes #129

Renamed the default SQLite database file from `mcp.db` to `mcpjungle.db` with full backward compatibility and deprecation warnings for existing installations.