### PR TITLE
Improve error message formatting for better UX

### DIFF
--- a/client/admin.go
+++ b/client/admin.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 	"net/url"
 
@@ -42,8 +41,7 @@ func (c *Client) InitServer() (*InitServerResponse, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var initResp InitServerResponse

--- a/client/client.go
+++ b/client/client.go
@@ -51,6 +51,33 @@ func (c *Client) newRequest(method, url string, body io.Reader) (*http.Request, 
 	return req, nil
 }
 
+// ErrorResponse represents the JSON structure of error responses from the server
+type ErrorResponse struct {
+	Error string `json:"error"`
+}
+
+// parseErrorResponse parses HTTP error responses (4xx and 5xx) and returns a user-friendly error message
+func (c *Client) parseErrorResponse(resp *http.Response) error {
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("request failed with status: %d (unable to read error details)", resp.StatusCode)
+	}
+
+	// For 4xx and 5xx status codes, try to parse as JSON error response
+	if resp.StatusCode >= 400 && resp.StatusCode < 600 {
+		var errorResp ErrorResponse
+		if err := json.Unmarshal(body, &errorResp); err != nil {
+			// If parsing as JSON fails, return the raw response
+			return fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, string(body))
+		}
+		// Return the parsed error message
+		return fmt.Errorf("%s", errorResp.Error)
+	}
+
+	// For any other status code, return the full response
+	return fmt.Errorf("unexpected response with status: %d, body: %s", resp.StatusCode, string(body))
+}
+
 // GetServerMetadata fetches metadata about the MCPJungle server.
 func (c *Client) GetServerMetadata(ctx context.Context) (*types.ServerMetadata, error) {
 	req, err := c.newRequest(http.MethodGet, c.baseURL+"/metadata", nil)
@@ -66,7 +93,7 @@ func (c *Client) GetServerMetadata(ctx context.Context) (*types.ServerMetadata, 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server returned status %d", resp.StatusCode)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var metadata types.ServerMetadata

--- a/client/client.go
+++ b/client/client.go
@@ -66,8 +66,9 @@ func (c *Client) parseErrorResponse(resp *http.Response) error {
 	// For 4xx and 5xx status codes, try to parse as JSON error response
 	if resp.StatusCode >= 400 && resp.StatusCode < 600 {
 		var errorResp ErrorResponse
-		if err := json.Unmarshal(body, &errorResp); err != nil {
-			// If parsing as JSON fails, return the raw response
+		err := json.Unmarshal(body, &errorResp)
+		if err != nil || errorResp.Error == "" {
+			// If parsing as JSON fails or the error message is empty, return the raw response
 			return fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, string(body))
 		}
 		// Return the parsed error message

--- a/client/mcp_clients.go
+++ b/client/mcp_clients.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/mcpjungle/mcpjungle/pkg/types"
@@ -25,8 +24,7 @@ func (c *Client) ListMcpClients() ([]types.McpClient, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var clients []types.McpClient
@@ -52,8 +50,7 @@ func (c *Client) DeleteMcpClient(name string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return c.parseErrorResponse(resp)
 	}
 
 	return nil
@@ -80,8 +77,7 @@ func (c *Client) CreateMcpClient(mcpClient *types.McpClient) (string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return "", fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return "", c.parseErrorResponse(resp)
 	}
 
 	var response struct {

--- a/client/mcp_server.go
+++ b/client/mcp_server.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/mcpjungle/mcpjungle/pkg/types"
@@ -31,8 +30,7 @@ func (c *Client) RegisterServer(server *types.RegisterServerInput) (*types.McpSe
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var registeredServer types.McpServer
@@ -57,8 +55,7 @@ func (c *Client) ListServers() ([]*types.McpServer, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var servers []*types.McpServer
@@ -80,8 +77,7 @@ func (c *Client) DeregisterServer(name string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("unexpected status from server: %s, body: %s", resp.Status, body)
+		return c.parseErrorResponse(resp)
 	}
 	return nil
 }

--- a/client/mcp_server_test.go
+++ b/client/mcp_server_test.go
@@ -270,7 +270,7 @@ func TestDeregisterServer(t *testing.T) {
 			t.Error("Expected error, got nil")
 		}
 
-		expectedError := "unexpected status from server: 404 Not Found, body: Server not found"
+		expectedError := "Server not found"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Errorf("Expected error to contain %s, got %s", expectedError, err.Error())
 		}

--- a/client/tool_group.go
+++ b/client/tool_group.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/mcpjungle/mcpjungle/pkg/types"
@@ -32,8 +31,7 @@ func (c *Client) CreateToolGroup(group *types.ToolGroup) (*types.CreateToolGroup
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var createResp types.CreateToolGroupResponse
@@ -59,8 +57,7 @@ func (c *Client) DeleteToolGroup(name string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return c.parseErrorResponse(resp)
 	}
 
 	return nil
@@ -82,8 +79,7 @@ func (c *Client) ListToolGroups() ([]types.ToolGroup, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var groups []types.ToolGroup
@@ -109,8 +105,7 @@ func (c *Client) GetToolGroup(name string) (*types.GetToolGroupResponse, error) 
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var group types.GetToolGroupResponse
@@ -141,8 +136,7 @@ func (c *Client) UpdateToolGroup(group *types.ToolGroup) (*types.UpdateToolGroup
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var updateResp types.UpdateToolGroupResponse

--- a/client/user.go
+++ b/client/user.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/http"
 
 	"github.com/mcpjungle/mcpjungle/pkg/types"
@@ -32,8 +31,7 @@ func (c *Client) CreateUser(user *types.CreateUserRequest) (*types.CreateUserRes
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusCreated {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var createResp types.CreateUserResponse
@@ -59,8 +57,7 @@ func (c *Client) DeleteUser(username string) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusNoContent {
-		body, _ := io.ReadAll(resp.Body)
-		return fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return c.parseErrorResponse(resp)
 	}
 
 	return nil
@@ -82,8 +79,7 @@ func (c *Client) ListUsers() ([]*types.User, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var users []*types.User
@@ -110,8 +106,7 @@ func (c *Client) Whoami(accessToken string) (*types.User, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("request failed with status: %d, message: %s", resp.StatusCode, body)
+		return nil, c.parseErrorResponse(resp)
 	}
 
 	var user types.User

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -113,7 +113,7 @@ func runCreateMcpClient(cmd *cobra.Command, args []string) error {
 
 	token, err := apiClient.CreateMcpClient(c)
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to create MCP client: %w", err)
 	}
 	if token == "" {
 		return fmt.Errorf("server returned an empty token, this was unexpected")


### PR DESCRIPTION
Fixes #124 

- Add parseErrorResponse helper to extract clean error messages from JSON responses
- Replace raw JSON error display with user-friendly error messages
- Update all client methods (tool groups, tools, users, servers, mcp clients, admin) to use consistent error handling
- Remove unused io imports across client files
- Update test expectation for deregister server error message format

Before: 'request failed with status: 404, message: {'error':'tool group does not exist'}'
After: 'tool group does not exist'

Fixes CLI error messages showing raw JSON responses instead of clean, readable error text.