### PR TITLE
fix(mode): enterprise mode msg

### DIFF
--- a/internal/service/mcp/proxy.go
+++ b/internal/service/mcp/proxy.go
@@ -87,8 +87,8 @@ func (m *MCPService) mcpProxyPromptHandler(ctx context.Context, request mcp.GetP
 	}
 
 	serverMode := ctx.Value("mode").(model.ServerMode)
-	if serverMode == model.ModeProd {
-		// In production mode, we need to check whether the MCP client is authorized to access the MCP server.
+	if model.IsEnterpriseMode(serverMode) {
+		// In enterprise mode, we need to check whether the MCP client is authorized to access the MCP server.
 		// If not, return error Unauthorized.
 		c := ctx.Value("client").(*model.McpClient)
 		if !c.CheckHasServerAccess(serverName) {


### PR DESCRIPTION
Any MCP client can call prompts from any MCP server, even if they don't have access to that server, the access control is not enforced for prompts.