### PR TITLE
Publish images to GHCR and update docs

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -79,6 +79,8 @@ dockers:
     image_templates:
       - "mcpjungle/mcpjungle:{{ .Tag }}-amd64"
       - "mcpjungle/mcpjungle:latest-amd64"
+      - "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-amd64"
+      - "ghcr.io/mcpjungle/mcpjungle:latest-amd64"
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -89,6 +91,8 @@ dockers:
     image_templates:
       - "mcpjungle/mcpjungle:{{ .Tag }}-arm64"
       - "mcpjungle/mcpjungle:latest-arm64"
+      - "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-arm64"
+      - "ghcr.io/mcpjungle/mcpjungle:latest-arm64"
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -99,6 +103,8 @@ dockers:
     image_templates:
       - "mcpjungle/mcpjungle:{{ .Tag }}-stdio-amd64"
       - "mcpjungle/mcpjungle:latest-stdio-amd64"
+      - "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-stdio-amd64"
+      - "ghcr.io/mcpjungle/mcpjungle:latest-stdio-amd64"
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -109,6 +115,8 @@ dockers:
     image_templates:
       - "mcpjungle/mcpjungle:{{ .Tag }}-stdio-arm64"
       - "mcpjungle/mcpjungle:latest-stdio-arm64"
+      - "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-stdio-arm64"
+      - "ghcr.io/mcpjungle/mcpjungle:latest-stdio-arm64"
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -135,3 +143,23 @@ docker_manifests:
     image_templates:
       - "mcpjungle/mcpjungle:latest-stdio-amd64"
       - "mcpjungle/mcpjungle:latest-stdio-arm64"
+
+  - name_template: "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}"
+    image_templates:
+      - "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-amd64"
+      - "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-arm64"
+
+  - name_template: "ghcr.io/mcpjungle/mcpjungle:latest"
+    image_templates:
+      - "ghcr.io/mcpjungle/mcpjungle:latest-amd64"
+      - "ghcr.io/mcpjungle/mcpjungle:latest-arm64"
+
+  - name_template: "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-stdio"
+    image_templates:
+      - "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-stdio-amd64"
+      - "ghcr.io/mcpjungle/mcpjungle:{{ .Tag }}-stdio-arm64"
+
+  - name_template: "ghcr.io/mcpjungle/mcpjungle:latest-stdio"
+    image_templates:
+      - "ghcr.io/mcpjungle/mcpjungle:latest-stdio-amd64"
+      - "ghcr.io/mcpjungle/mcpjungle:latest-stdio-arm64"

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ mcpjungle version
 MCPJungle provides a Docker image which is useful for running the registry server (more about it later).
 
 ```bash
-docker pull mcpjungle/mcpjungle
+docker pull ghcr.io/mcpjungle/mcpjungle
 ```
 
 # Usage
@@ -190,7 +190,7 @@ But if you also want to use stdio-based servers like `filesystem`, `time`, `gith
 
 **Production Deployment**
 
-The default [MCPJungle Docker image](https://hub.docker.com/r/mcpjungle/mcpjungle) is very lightweight - it only contains a minimal base image and the `mcpjungle` binary.
+The default [MCPJungle Docker image](https://github.com/mcpjungle/MCPJungle/pkgs/container/mcpjungle) is very lightweight - it only contains a minimal base image and the `mcpjungle` binary.
 
 It is therefore suitable and recommended for production deployments.
 
@@ -226,7 +226,7 @@ For more serious deployments, mcpjungle also supports Postgresql. You can supply
 export DATABASE_URL=postgres://admin:root@localhost:5432/mcpjungle_db
 
 #run as container
-docker run mcpjungle/mcpjungle:latest
+docker run ghcr.io/mcpjungle/mcpjungle:latest
 
 # or run directly
 mcpjungle start

--- a/docker-compose.prod.yaml
+++ b/docker-compose.prod.yaml
@@ -32,7 +32,7 @@ services:
       - db
 
   mcpjungle:
-    image: mcpjungle/mcpjungle:${MCPJUNGLE_IMAGE_TAG:-latest}
+    image: ghcr.io/mcpjungle/mcpjungle:${MCPJUNGLE_IMAGE_TAG:-latest}
     container_name: mcpjungle-server
     environment:
       DATABASE_URL: postgres://mcpjungle:mcpjungle@db:5432/mcpjungle

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
     restart: unless-stopped
 
   mcpjungle:
-    image: mcpjungle/mcpjungle:${MCPJUNGLE_IMAGE_TAG:-latest-stdio}
+    image: ghcr.io/mcpjungle/mcpjungle:${MCPJUNGLE_IMAGE_TAG:-latest-stdio}
     container_name: mcpjungle-server
     environment:
       DATABASE_URL: postgres://mcpjungle:mcpjungle@db:5432/mcpjungle


### PR DESCRIPTION
### Motivation

- Publish MCPJungle Docker images to GitHub Container Registry (GHCR) in addition to Docker Hub to keep artifacts inside the GitHub ecosystem and improve visibility and stats.
- Ensure default docker-compose pulls and README examples point to GHCR so users get the GHCR-hosted images by default.

### Description

- Updated `.goreleaser.yaml` to add `ghcr.io/mcpjungle/mcpjungle` image templates for all architectures and `stdio` variants and added GHCR entries to the `docker_manifests` section.
- Updated `docker-compose.yaml` and `docker-compose.prod.yaml` to use `ghcr.io/mcpjungle/mcpjungle` as the default image reference via the `MCPJUNGLE_IMAGE_TAG` variable.
- Updated `README.md` to replace `docker pull`/`docker run` examples and the Docker Hub link with the GHCR package URL.

### Testing

- No automated tests were run for these documentation and CI/configuration changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696a2aaf4f748332a1aa6b0d028c0d08)