### PR TITLE
fix: "[WARN] failed to register prompts for MCP server" warning

### DIFF
--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -33,8 +33,10 @@ func (m *MCPService) RegisterMcpServer(ctx context.Context, s *model.McpServer) 
 	}
 
 	// Register prompts (best-effort, don't fail server registration)
-	if err = m.registerServerPrompts(ctx, s, mcpClient); err != nil {
-		log.Printf("[WARN] failed to register prompts for MCP server %s: %v", s.Name, err)
+	if mcpClient.GetServerCapabilities().Prompts != nil {
+		if err = m.registerServerPrompts(ctx, s, mcpClient); err != nil {
+			log.Printf("[WARN] failed to register prompts for MCP server %s: %v", s.Name, err)
+		}
 	}
 
 	return nil


### PR DESCRIPTION
Added capabilities prompts check before registering prompts to prevent warning