### PR TITLE
add oidc support

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ MCPJungle is an open source, self-hosted Gateway for all your [Model Context Pro
   - [Prompts](#prompts)
   - [Tool Groups](#tool-groups)
   - [Authentication](#authentication)
+  - [OAuth 2.0 Integration](#oauth-20-integration)
   - [Enterprise features](#enterprise-features-)
     - [Access Control](#access-control)
     - [OpenTelemetry](#opentelemetry)
@@ -665,7 +666,41 @@ Or from your configuration file
 }
 ```
 
-Support for Oauth flow is coming soon!
+## OAuth 2.0 Integration
+
+MCPJungle supports OAuth 2.0 / OpenID Connect (OIDC) for connecting external LLM platforms like ChatGPT. This uses the Authorization Code flow with PKCE for security.
+
+OAuth is only available in Enterprise mode.
+
+### Setting Up OAuth for ChatGPT
+
+1. Start MCPJungle in enterprise mode and initialize it:
+```bash
+mcpjungle start --enterprise
+mcpjungle init-server
+```
+
+2. Create an OAuth client:
+```bash
+mcpjungle create oauth-client chatgpt \
+  --redirect-uris "https://chatgpt.com/connector_platform_oauth_redirect"
+```
+
+3. Expose MCPJungle publicly (for local development, use [ngrok](https://ngrok.com/)):
+```bash
+ngrok http 8080
+```
+
+4. In ChatGPT, go to **Settings > Connectors > Advanced > Developer mode** and add a connector:
+   - Endpoint URL: `https://your-ngrok-url/mcp`
+   - Authentication: **OAuth**
+   - Client ID: (from step 2)
+   - Authorize URL: `https://your-ngrok-url/oauth/authorize`
+   - Token URL: `https://your-ngrok-url/oauth/token`
+
+5. When prompted, authorize access using your MCPJungle username and access token.
+
+MCPJungle exposes OAuth discovery endpoints at `/.well-known/openid-configuration` and `/.well-known/oauth-protected-resource` for automatic client configuration.
 
 ## Enterprise Features 🔒
 
@@ -818,10 +853,9 @@ Once the mcpjungle server is started, metrics are available at the `/metrics` en
 # Current limitations 🚧
 We're not perfect yet, but we're working hard to get there!
 
-### 1. MCPJungle does not support OAuth flow for authentication yet
-This is a work in progress.
+### 1. OAuth refresh token flow
 
-We're collecting more feedback on how people use OAuth with MCP servers, so feel free to start a Discussion or open an issue to share your use case.
+While MCPJungle issues refresh tokens during the OAuth flow, the token refresh endpoint is not yet implemented. Users will need to re-authorize when their access tokens expire (after 24 hours). This will be added in a future release.
 
 # Contributing 💻
 

--- a/client/admin.go
+++ b/client/admin.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 
 	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/pkg/types"
 )
 
 type InitServerResponse struct {
@@ -49,4 +50,35 @@ func (c *Client) InitServer() (*InitServerResponse, error) {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 	return &initResp, nil
+}
+
+// CreateOAuthClient creates a new OAuth client in the registry
+func (c *Client) CreateOAuthClient(client *types.CreateOAuthClientRequest) (*model.OAuthClient, error) {
+	u, err := c.constructAPIEndpoint("/oauth-clients")
+	if err != nil {
+		return nil, err
+	}
+	body, err := json.Marshal(client)
+	if err != nil {
+		return nil, err
+	}
+	req, err := c.newRequest(http.MethodPost, u, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusCreated {
+		return nil, c.parseErrorResponse(resp)
+	}
+
+	var created model.OAuthClient
+	if err := json.NewDecoder(resp.Body).Decode(&created); err != nil {
+		return nil, err
+	}
+	return &created, nil
 }

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -75,6 +75,14 @@ var createToolGroupCmd = &cobra.Command{
 	RunE: runCreateToolGroup,
 }
 
+var createOAuthClientCmd = &cobra.Command{
+	Use:   "oauth-client [name]",
+	Args:  cobra.ExactArgs(1),
+	Short: "Create an OAuth 2.0 client (Enterprise mode)",
+	Long:  "Create an OAuth 2.0 client for integrating with external LLMs like ChatGPT.",
+	RunE:  runCreateOAuthClient,
+}
+
 var (
 	createMcpClientCmdAllowedServers string
 	createMcpClientCmdDescription    string
@@ -85,6 +93,9 @@ var (
 	createUserCmdConfigFilePath string
 
 	createToolGroupConfigFilePath string
+
+	createOAuthClientCmdRedirectURIs string
+	createOAuthClientCmdDescription  string
 )
 
 func init() {
@@ -142,9 +153,24 @@ func init() {
 	)
 	_ = createToolGroupCmd.MarkFlagRequired("conf")
 
+	createOAuthClientCmd.Flags().StringVar(
+		&createOAuthClientCmdRedirectURIs,
+		"redirect-uris",
+		"",
+		"Comma-separated list of allowed redirect URIs",
+	)
+	createOAuthClientCmd.Flags().StringVar(
+		&createOAuthClientCmdDescription,
+		"description",
+		"",
+		"Description of the OAuth client",
+	)
+	_ = createOAuthClientCmd.MarkFlagRequired("redirect-uris")
+
 	createCmd.AddCommand(createMcpClientCmd)
 	createCmd.AddCommand(createUserCmd)
 	createCmd.AddCommand(createToolGroupCmd)
+	createCmd.AddCommand(createOAuthClientCmd)
 
 	rootCmd.AddCommand(createCmd)
 }
@@ -292,6 +318,28 @@ func runCreateToolGroup(cmd *cobra.Command, args []string) error {
 	cmd.Print("Tools using the SSE (server-sent events) transport are accessible at:\n\n")
 	cmd.Println("    " + resp.SSEEndpoint)
 	cmd.Println("    " + resp.SSEMessageEndpoint + "\n")
+
+	return nil
+}
+
+func runCreateOAuthClient(cmd *cobra.Command, args []string) error {
+	req := &types.CreateOAuthClientRequest{
+		Name:         args[0],
+		RedirectURIs: createOAuthClientCmdRedirectURIs,
+		Description:  createOAuthClientCmdDescription,
+	}
+
+	created, err := apiClient.CreateOAuthClient(req)
+	if err != nil {
+		return fmt.Errorf("failed to create OAuth client: %w", err)
+	}
+
+	cmd.Printf("OAuth client '%s' created successfully!\n", created.Name)
+	cmd.Printf("Client ID:     %s\n", created.ClientID)
+	if created.ClientSecret != "" {
+		cmd.Printf("Client Secret: %s\n", created.ClientSecret)
+	}
+	cmd.Printf("Redirect URIs: %s\n", created.RedirectURIs)
 
 	return nil
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -23,6 +23,7 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/service/config"
 	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
 	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
+	"github.com/mcpjungle/mcpjungle/internal/service/oauth"
 	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
 	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/mcpjungle/mcpjungle/internal/telemetry"
@@ -425,6 +426,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 
 	configService := config.NewServerConfigService(dbConn)
 	userService := user.NewUserService(dbConn)
+	oauthService := oauth.NewOAuthService(dbConn)
 
 	toolGroupService, err := toolgroup.NewToolGroupService(dbConn, mcpService)
 	if err != nil {
@@ -437,6 +439,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		SseMcpProxyServer: sseMcpProxyServer,
 		MCPService:        mcpService,
 		MCPClientService:  mcpClientService,
+		OAuthService:      oauthService,
 		ConfigService:     configService,
 		UserService:       userService,
 		ToolGroupService:  toolGroupService,

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -169,16 +169,38 @@ func (s *Server) checkAuthForMcpProxyAccess() gin.HandlerFunc {
 			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "missing MCP client access token"})
 			return
 		}
+
+		// First, check if it's a static MCP client token (legacy authentication method)
+		// Static tokens are created via `mcpjungle create mcp-client` and are long-lived.
 		client, err := s.mcpClientService.GetClientByToken(token)
-		if err != nil {
-			c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid MCP client token"})
+		if err == nil {
+			// inject the authenticated MCP client in context for the proxy to use
+			ctx = context.WithValue(c.Request.Context(), "client", client)
+			c.Request = c.Request.WithContext(ctx)
+			c.Next()
 			return
 		}
 
-		// inject the authenticated MCP client in context for the proxy to use
-		ctx = context.WithValue(c.Request.Context(), "client", client)
-		c.Request = c.Request.WithContext(ctx)
+		// Second, check if it's an OAuth token issued by mcpjungle (OAuth 2.0 flow)
+		// OAuth tokens are issued via the /oauth/token endpoint after user authorization.
+		// They are tied to a specific MCPJungle user and have expiration times.
+		oauthToken, err := s.oauthService.GetTokenByValue(token)
+		if err == nil {
+			// Create a "virtual" McpClient for the OAuth-authenticated user.
+			// This allows us to reuse the existing proxy authorization logic without major changes.
+			// The virtual client represents the user's OAuth session.
+			// TODO: Implement proper User -> Server ACLs instead of wildcard access.
+			virtualClient := &model.McpClient{
+				Name:        "oauth-user-" + fmt.Sprint(oauthToken.UserID),
+				AccessToken: oauthToken.Token,
+				AllowList:   []byte("[\"*\"]"), // Wildcard access for authenticated users for now
+			}
+			ctx = context.WithValue(c.Request.Context(), "client", virtualClient)
+			c.Request = c.Request.WithContext(ctx)
+			c.Next()
+			return
+		}
 
-		c.Next()
+		c.AbortWithStatusJSON(http.StatusUnauthorized, gin.H{"error": "invalid access token"})
 	}
 }

--- a/internal/api/oauth.go
+++ b/internal/api/oauth.go
@@ -1,0 +1,253 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/gin-gonic/gin"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/internal/service/oauth"
+	"github.com/mcpjungle/mcpjungle/pkg/types"
+)
+
+// oidcConfigurationHandler returns the OpenID Connect discovery document.
+// This endpoint is required by OAuth 2.0/OIDC clients (like ChatGPT) to discover
+// the authorization server's capabilities and endpoints.
+// It follows the OIDC Discovery specification: https://openid.net/specs/openid-connect-discovery-1_0.html
+func (s *Server) oidcConfigurationHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		baseURL := getBaseURL(c)
+		config := gin.H{
+			"issuer":                                baseURL,
+			"authorization_endpoint":                baseURL + "/oauth/authorize",
+			"token_endpoint":                        baseURL + "/oauth/token",
+			"response_types_supported":              []string{"code"},
+			"subject_types_supported":               []string{"public"},
+			"id_token_signing_alg_values_supported": []string{"RS256"},
+			"scopes_supported":                      []string{"openid", "profile", "offline_access"},
+			"token_endpoint_auth_methods_supported": []string{"client_secret_basic", "client_secret_post", "none"},
+			"code_challenge_methods_supported":      []string{"plain", "S256"},
+		}
+		c.JSON(http.StatusOK, config)
+	}
+}
+
+// oauthProtectedResourceHandler returns the OAuth 2.0 protected resource metadata.
+// This endpoint helps clients discover the resource server's authorization requirements.
+// It's used by ChatGPT to understand what scopes are needed and where to get authorization.
+func (s *Server) oauthProtectedResourceHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		baseURL := getBaseURL(c)
+		metadata := gin.H{
+			"resource":              baseURL,
+			"authorization_servers": []string{baseURL},
+			"scopes_supported":      []string{"mcp"},
+		}
+		c.JSON(http.StatusOK, metadata)
+	}
+}
+
+// oauthAuthorizeHandler handles the OAuth 2.0 authorization endpoint.
+// This implements the authorization step of the Authorization Code flow with PKCE.
+// GET: Displays an authorization form where users can grant access to the OAuth client.
+// POST: Processes the authorization, generates an authorization code, and redirects back to the client.
+// The authorization code is then exchanged for an access token via the token endpoint.
+func (s *Server) oauthAuthorizeHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Extract OAuth 2.0 authorization request parameters
+		clientID := c.Query("client_id")
+		redirectURI := c.Query("redirect_uri")
+		state := c.Query("state")                               // CSRF protection token
+		codeChallenge := c.Query("code_challenge")              // PKCE challenge
+		codeChallengeMethod := c.Query("code_challenge_method") // PKCE method (S256 or plain)
+		scope := c.Query("scope")                               // Requested permissions
+
+		// GET request: Show authorization form
+		if c.Request.Method == http.MethodGet {
+			// In a production app, this would show a proper login/consent page.
+			// For MCPJungle, we use a simple HTML form where users enter their
+			// username and CLI access token to authorize the OAuth client.
+			html := fmt.Sprintf(`
+				<html>
+				<body>
+					<h2>Authorize MCPJungle Access</h2>
+					<form method="POST">
+						<input type="hidden" name="client_id" value="%s">
+						<input type="hidden" name="redirect_uri" value="%s">
+						<input type="hidden" name="state" value="%s">
+						<input type="hidden" name="code_challenge" value="%s">
+						<input type="hidden" name="code_challenge_method" value="%s">
+						<input type="hidden" name="scope" value="%s">
+						<div>
+							<label>Username:</label>
+							<input type="text" name="username" required>
+						</div>
+						<div>
+							<label>Access Token (from mcpjungle CLI):</label>
+							<input type="password" name="access_token" required>
+						</div>
+						<button type="submit">Authorize</button>
+					</form>
+				</body>
+				</html>
+			`, clientID, redirectURI, state, codeChallenge, codeChallengeMethod, scope)
+			c.Data(http.StatusOK, "text/html; charset=utf-8", []byte(html))
+			return
+		}
+
+		// POST request: Process authorization
+		username := c.PostForm("username")
+		accessToken := c.PostForm("access_token")
+
+		// Verify user credentials using their MCPJungle CLI access token
+		user, err := s.userService.GetUserByAccessToken(accessToken)
+		if err != nil || user.Username != username {
+			c.JSON(http.StatusUnauthorized, gin.H{"error": "invalid username or access token"})
+			return
+		}
+
+		// Generate authorization code (short-lived, single-use)
+		code, err := s.oauthService.CreateAuthorizeCode(
+			c.Request.Context(),
+			c.PostForm("client_id"),
+			user.ID,
+			c.PostForm("redirect_uri"),
+			c.PostForm("scope"),
+			c.PostForm("code_challenge"),
+			c.PostForm("code_challenge_method"),
+		)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "failed to generate code"})
+			return
+		}
+
+		// Redirect back to the OAuth client with the authorization code
+		// The client will then exchange this code for an access token
+		targetRedirectURI := c.PostForm("redirect_uri")
+		if strings.Contains(targetRedirectURI, "?") {
+			targetRedirectURI += "&"
+		} else {
+			targetRedirectURI += "?"
+		}
+		// Include the authorization code and state (for CSRF protection)
+		targetRedirectURI += fmt.Sprintf("code=%s&state=%s", code, c.PostForm("state"))
+
+		c.Redirect(http.StatusFound, targetRedirectURI)
+	}
+}
+
+// oauthTokenHandler handles the OAuth 2.0 token endpoint.
+// This exchanges an authorization code for an access token and refresh token.
+// It implements the token exchange step of the Authorization Code flow with PKCE.
+// The authorization code must be valid, not expired, and the PKCE verifier must match.
+func (s *Server) oauthTokenHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Only support authorization_code grant type
+		grantType := c.PostForm("grant_type")
+		if grantType != "authorization_code" {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "unsupported grant type"})
+			return
+		}
+
+		// Extract token exchange parameters
+		code := c.PostForm("code")                  // Authorization code from authorize endpoint
+		clientID := c.PostForm("client_id")         // OAuth client identifier
+		codeVerifier := c.PostForm("code_verifier") // PKCE verifier (original random string)
+
+		// Exchange code for token (validates PKCE, expiration, etc.)
+		token, err := s.oauthService.ExchangeCodeForToken(code, clientID, codeVerifier)
+		if err != nil {
+			status := http.StatusBadRequest
+			// Invalid or expired codes should return 401
+			if err == oauth.ErrInvalidCode || err == oauth.ErrExpiredCode {
+				status = http.StatusUnauthorized
+			}
+			c.JSON(status, gin.H{"error": err.Error()})
+			return
+		}
+
+		// Return token response according to OAuth 2.0 spec
+		c.JSON(http.StatusOK, gin.H{
+			"access_token":  token.Token,
+			"refresh_token": token.RefreshToken,
+			"token_type":    "Bearer",
+			"expires_in":    int(token.ExpiresAt.Sub(token.CreatedAt).Seconds()),
+			"scope":         token.Scope,
+		})
+	}
+}
+
+// getBaseURL constructs the base URL for the current request.
+// It handles both direct HTTPS connections and proxied connections (e.g., via ngrok).
+// The X-Forwarded-Proto header is checked to support reverse proxies.
+func getBaseURL(c *gin.Context) string {
+	scheme := "http"
+	if c.Request.TLS != nil {
+		scheme = "https"
+	}
+	// Check for X-Forwarded-Proto (important for ngrok and other reverse proxies)
+	if proto := c.GetHeader("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	}
+	return fmt.Sprintf("%s://%s", scheme, c.Request.Host)
+}
+
+// createOAuthClientHandler handles the creation of a new OAuth 2.0 client.
+// This is an admin-only endpoint that allows registering external services (like ChatGPT)
+// that want to connect to MCPJungle via OAuth.
+// The client will receive a ClientID that it uses to initiate OAuth flows.
+func (s *Server) createOAuthClientHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var req types.CreateOAuthClientRequest
+		if err := c.ShouldBindJSON(&req); err != nil {
+			c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+			return
+		}
+
+		// Create the OAuth client model
+		client := &model.OAuthClient{
+			Name:         req.Name,
+			RedirectURIs: req.RedirectURIs,
+			Description:  req.Description,
+			ClientID:     req.ClientID,
+			ClientSecret: req.ClientSecret,
+		}
+
+		// Save to database (ClientID auto-generated if not provided)
+		created, err := s.oauthService.CreateClient(client)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		c.JSON(http.StatusCreated, created)
+	}
+}
+
+// listOAuthClientsHandler handles listing all registered OAuth clients.
+// This is an admin-only endpoint useful for managing OAuth integrations.
+func (s *Server) listOAuthClientsHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clients, err := s.oauthService.ListClients()
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.JSON(http.StatusOK, clients)
+	}
+}
+
+// deleteOAuthClientHandler handles deleting an OAuth client.
+// This immediately revokes access for that client - any tokens issued to it become invalid.
+// This is an admin-only endpoint.
+func (s *Server) deleteOAuthClientHandler() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		clientID := c.Param("client_id")
+		if err := s.oauthService.DeleteClient(clientID); err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		c.Status(http.StatusNoContent)
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -12,6 +12,7 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/service/config"
 	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
 	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
+	"github.com/mcpjungle/mcpjungle/internal/service/oauth"
 	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
 	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/mcpjungle/mcpjungle/internal/telemetry"
@@ -39,6 +40,7 @@ type ServerOptions struct {
 
 	MCPService       *mcp.MCPService
 	MCPClientService *mcpclient.McpClientService
+	OAuthService     *oauth.OAuthService
 	ConfigService    *config.ServerConfigService
 	UserService      *user.UserService
 	ToolGroupService *toolgroup.ToolGroupService
@@ -56,6 +58,7 @@ type Server struct {
 
 	mcpService       *mcp.MCPService
 	mcpClientService *mcpclient.McpClientService
+	oauthService     *oauth.OAuthService
 
 	configService    *config.ServerConfigService
 	userService      *user.UserService
@@ -77,6 +80,7 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 		sseMcpProxyServer: opts.SseMcpProxyServer,
 		mcpService:        opts.MCPService,
 		mcpClientService:  opts.MCPClientService,
+		oauthService:      opts.OAuthService,
 		configService:     opts.ConfigService,
 		userService:       opts.UserService,
 		toolGroupService:  opts.ToolGroupService,
@@ -167,6 +171,13 @@ func (s *Server) setupRouter() (*gin.Engine, error) {
 	)
 
 	r.POST("/init", s.registerInitServerHandler())
+
+	// OAuth 2.0 / OIDC endpoints
+	r.GET("/.well-known/openid-configuration", s.oidcConfigurationHandler())
+	r.GET("/.well-known/oauth-protected-resource", s.oauthProtectedResourceHandler())
+	r.GET("/oauth/authorize", s.oauthAuthorizeHandler())
+	r.POST("/oauth/authorize", s.oauthAuthorizeHandler()) // Handles the actual authorization form POST
+	r.POST("/oauth/token", s.oauthTokenHandler())
 
 	requireEnterpriseMode := s.requireServerMode(model.ModeEnterprise)
 
@@ -306,6 +317,11 @@ func (s *Server) setupRouter() (*gin.Engine, error) {
 		adminAPI.GET("/tool-groups", s.listToolGroupsHandler())
 		adminAPI.DELETE("/tool-groups/:name", s.deleteToolGroupHandler())
 		adminAPI.PUT("/tool-groups/:name", s.updateToolGroupHandler())
+
+		// OAuth client management
+		adminAPI.POST("/oauth-clients", s.createOAuthClientHandler())
+		adminAPI.GET("/oauth-clients", s.listOAuthClientsHandler())
+		adminAPI.DELETE("/oauth-clients/:client_id", s.deleteOAuthClientHandler())
 	}
 
 	return r, nil

--- a/internal/migrations/migration.go
+++ b/internal/migrations/migration.go
@@ -31,5 +31,14 @@ func Migrate(db *gorm.DB) error {
 	if err := db.AutoMigrate(&model.Prompt{}); err != nil {
 		return fmt.Errorf("auto‑migration failed for Prompt model: %v", err)
 	}
+	if err := db.AutoMigrate(&model.OAuthClient{}); err != nil {
+		return fmt.Errorf("auto‑migration failed for OAuthClient model: %v", err)
+	}
+	if err := db.AutoMigrate(&model.OAuthCode{}); err != nil {
+		return fmt.Errorf("auto‑migration failed for OAuthCode model: %v", err)
+	}
+	if err := db.AutoMigrate(&model.OAuthToken{}); err != nil {
+		return fmt.Errorf("auto‑migration failed for OAuthToken model: %v", err)
+	}
 	return nil
 }

--- a/internal/model/oauth.go
+++ b/internal/model/oauth.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"time"
+
+	"gorm.io/gorm"
+)
+
+// OAuthClient represents an OAuth 2.0 client application that can request access to MCPJungle resources.
+// This is used when external services (like ChatGPT) want to connect to MCPJungle using OAuth 2.0.
+// The client must be registered before it can initiate the OAuth flow.
+type OAuthClient struct {
+	gorm.Model
+	// ClientID is a unique identifier for the OAuth client. If not provided during creation,
+	// it will be auto-generated. This is what external services use to identify themselves.
+	ClientID string `json:"client_id" gorm:"uniqueIndex;not null"`
+
+	// ClientSecret is optional and only used for confidential clients. For public clients
+	// using PKCE (like ChatGPT), this can be empty.
+	ClientSecret string `json:"client_secret"` // Optional for public clients/PKCE
+
+	// Name is a human-readable name for the client (e.g., "ChatGPT", "Claude").
+	Name string `json:"name" gorm:"not null"`
+	// RedirectURIs contains the allowed redirect URIs where the authorization server
+	// can send users after they authorize the client. For ChatGPT, this should be:
+	// "https://chatgpt.com/connector_platform_oauth_redirect"
+	RedirectURIs string `json:"redirect_uris"` // Comma-separated or JSON list
+
+	// Description provides additional context about the client.
+	Description string `json:"description"`
+}
+
+// OAuthCode represents a temporary authorization code issued during the OAuth 2.0 authorization flow.
+// This code is short-lived (10 minutes) and can only be used once to exchange for an access token.
+// It implements the Authorization Code flow with PKCE support for enhanced security.
+type OAuthCode struct {
+	gorm.Model
+	// Code is the authorization code that will be exchanged for an access token.
+	// It's a one-time use, short-lived token.
+	Code string `gorm:"uniqueIndex;not null"`
+
+	// ClientID identifies which OAuth client requested this authorization.
+	ClientID string `gorm:"not null"`
+
+	// UserID identifies the MCPJungle user who authorized the client.
+	UserID uint `gorm:"not null"` // The user who authorized
+
+	// ExpiresAt is when this code becomes invalid. Typically 10 minutes from creation.
+	ExpiresAt time.Time `gorm:"not null"`
+
+	// RedirectURI is the URI where the client should receive the authorization code.
+	RedirectURI string
+
+	// CodeChallenge is used for PKCE (Proof Key for Code Exchange) to prevent authorization
+	// code interception attacks. It's the hashed value of the code_verifier.
+	CodeChallenge string // For PKCE
+
+	// CodeChallengeMethod specifies the hashing method used (e.g., "S256" or "plain").
+	CodeChallengeMethod string
+
+	// Scope contains the requested permissions (e.g., "mcp", "openid", "profile").
+	Scope string
+}
+
+// OAuthToken represents an access token issued via the OAuth 2.0 flow.
+// This token is what external services use to authenticate API requests to MCPJungle.
+// Tokens are long-lived (24 hours) and can be refreshed using the refresh token.
+type OAuthToken struct {
+	gorm.Model
+	// Token is the access token that clients use in the Authorization header.
+	Token string `gorm:"uniqueIndex;not null"`
+
+	// RefreshToken can be used to obtain a new access token when the current one expires.
+	RefreshToken string `gorm:"uniqueIndex"`
+
+	// ClientID identifies which OAuth client this token was issued to.
+	ClientID string `gorm:"not null"`
+
+	// UserID identifies the MCPJungle user associated with this token.
+	UserID uint `gorm:"not null"`
+
+	// ExpiresAt is when this token becomes invalid. Typically 24 hours from creation.
+	ExpiresAt time.Time `gorm:"not null"`
+
+	// Scope contains the permissions granted to this token.
+	Scope string
+}

--- a/internal/service/oauth/oauth.go
+++ b/internal/service/oauth/oauth.go
@@ -1,0 +1,193 @@
+package oauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/mcpjungle/mcpjungle/internal"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"gorm.io/gorm"
+)
+
+var (
+	// ErrInvalidClient is returned when an OAuth client cannot be found or is invalid.
+	ErrInvalidClient = errors.New("invalid client")
+
+	// ErrExpiredCode is returned when an authorization code has expired.
+	ErrExpiredCode = errors.New("expired code")
+
+	// ErrInvalidCode is returned when an authorization code is invalid or not found.
+	ErrInvalidCode = errors.New("invalid code")
+)
+
+// OAuthService provides methods to manage OAuth 2.0 clients, authorization codes, and tokens.
+type OAuthService struct {
+	db *gorm.DB
+}
+
+// NewOAuthService creates a new instance of OAuthService.
+func NewOAuthService(db *gorm.DB) *OAuthService {
+	return &OAuthService{db: db}
+}
+
+// CreateClient creates a new OAuth 2.0 client in the database.
+// If no ClientID is provided, one will be auto-generated.
+func (s *OAuthService) CreateClient(client *model.OAuthClient) (*model.OAuthClient, error) {
+	// Auto-generate ClientID if not provided
+	if client.ClientID == "" {
+		id, err := internal.GenerateAccessToken()
+		if err != nil {
+			return nil, err
+		}
+		client.ClientID = id
+	}
+	if err := s.db.Create(client).Error; err != nil {
+		return nil, fmt.Errorf("failed to create oauth client: %w", err)
+	}
+	return client, nil
+}
+
+// GetClient retrieves an OAuth client by its ClientID.
+func (s *OAuthService) GetClient(clientID string) (*model.OAuthClient, error) {
+	var client model.OAuthClient
+	if err := s.db.Where("client_id = ?", clientID).First(&client).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrInvalidClient
+		}
+		return nil, err
+	}
+	return &client, nil
+}
+
+// CreateAuthorizeCode generates a new authorization code for the OAuth 2.0 Authorization Code flow.
+// This code is short-lived (10 minutes) and can only be used once.
+func (s *OAuthService) CreateAuthorizeCode(ctx context.Context, clientID string, userID uint, redirectURI string, scope string, codeChallenge string, codeChallengeMethod string) (string, error) {
+	// Generate a secure, random authorization code
+	code, err := internal.GenerateAccessToken()
+	if err != nil {
+		return "", err
+	}
+
+	// Create the authorization code record with 10-minute expiration
+	authCode := model.OAuthCode{
+		Code:                code,
+		ClientID:            clientID,
+		UserID:              userID,
+		RedirectURI:         redirectURI,
+		Scope:               scope,
+		CodeChallenge:       codeChallenge,
+		CodeChallengeMethod: codeChallengeMethod,
+		ExpiresAt:           time.Now().Add(10 * time.Minute),
+	}
+
+	if err := s.db.Create(&authCode).Error; err != nil {
+		return "", fmt.Errorf("failed to save authorization code: %w", err)
+	}
+
+	return code, nil
+}
+
+// ExchangeCodeForToken validates an authorization code and exchanges it for an access token.
+// This implements the token endpoint of the OAuth 2.0 Authorization Code flow.
+// The authorization code is single-use and will be deleted after successful exchange.
+// PKCE verification is performed if a code challenge was provided during authorization.
+// Returns an access token (24-hour lifetime) and a refresh token.
+func (s *OAuthService) ExchangeCodeForToken(code string, clientID string, codeVerifier string) (*model.OAuthToken, error) {
+	// Find the authorization code
+	var authCode model.OAuthCode
+	if err := s.db.Where("code = ? AND client_id = ?", code, clientID).First(&authCode).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, ErrInvalidCode
+		}
+		return nil, err
+	}
+
+	// Delete the code once it's used (one-time use, even if exchange fails)
+	defer s.db.Unscoped().Delete(&authCode)
+
+	// Check if code has expired
+	if time.Now().After(authCode.ExpiresAt) {
+		return nil, ErrExpiredCode
+	}
+
+	// Verify PKCE if present (required for public clients like ChatGPT)
+	if authCode.CodeChallenge != "" {
+		if !verifyPKCE(authCode.CodeChallenge, authCode.CodeChallengeMethod, codeVerifier) {
+			return nil, errors.New("pkce verification failed")
+		}
+	}
+
+	// Generate access token (long-lived, 24 hours)
+	tokenStr, err := internal.GenerateAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	// Generate refresh token (for token renewal)
+	refreshTokenStr, err := internal.GenerateAccessToken()
+	if err != nil {
+		return nil, err
+	}
+
+	// Create the token record
+	token := model.OAuthToken{
+		Token:        tokenStr,
+		RefreshToken: refreshTokenStr,
+		ClientID:     clientID,
+		UserID:       authCode.UserID,
+		Scope:        authCode.Scope,
+		ExpiresAt:    time.Now().Add(24 * time.Hour), // 24h expiration
+	}
+
+	if err := s.db.Create(&token).Error; err != nil {
+		return nil, fmt.Errorf("failed to save oauth token: %w", err)
+	}
+
+	return &token, nil
+}
+
+// GetTokenByValue retrieves an OAuth token by its value and validates that it hasn't expired.
+func (s *OAuthService) GetTokenByValue(tokenStr string) (*model.OAuthToken, error) {
+	var token model.OAuthToken
+	if err := s.db.Where("token = ?", tokenStr).First(&token).Error; err != nil {
+		return nil, err
+	}
+	// Check expiration
+	if time.Now().After(token.ExpiresAt) {
+		return nil, errors.New("token expired")
+	}
+	return &token, nil
+}
+
+// verifyPKCE verifies a PKCE (Proof Key for Code Exchange) challenge.
+// PKCE is a security extension for OAuth 2.0 that prevents authorization code interception attacks.
+func verifyPKCE(challenge, method, verifier string) bool {
+	if method == "S256" {
+		// Compute SHA256 hash of the verifier
+		h := sha256.New()
+		h.Write([]byte(verifier))
+		// Base64URL encode without padding
+		expected := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(h.Sum(nil))
+		return expected == challenge
+	}
+	// Plain method: direct comparison (less secure)
+	return verifier == challenge
+}
+
+// ListClients retrieves all registered OAuth clients from the database.
+func (s *OAuthService) ListClients() ([]model.OAuthClient, error) {
+	var clients []model.OAuthClient
+	if err := s.db.Find(&clients).Error; err != nil {
+		return nil, err
+	}
+	return clients, nil
+}
+
+// DeleteClient removes an OAuth client from the database.
+func (s *OAuthService) DeleteClient(clientID string) error {
+	return s.db.Unscoped().Where("client_id = ?", clientID).Delete(&model.OAuthClient{}).Error
+}

--- a/internal/service/oauth/oauth_test.go
+++ b/internal/service/oauth/oauth_test.go
@@ -1,0 +1,384 @@
+package oauth
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
+)
+
+func TestCreateClient(t *testing.T) {
+	tests := []struct {
+		name        string
+		client      *model.OAuthClient
+		wantError   bool
+		expectID    bool
+		description string
+	}{
+		{
+			name: "auto-generate client ID",
+			client: &model.OAuthClient{
+				Name:         "test-client",
+				RedirectURIs: "https://example.com/callback",
+				Description:  "Test OAuth client",
+			},
+			wantError: false,
+			expectID:  true,
+		},
+		{
+			name: "duplicate client ID should fail",
+			client: &model.OAuthClient{
+				ClientID:     "duplicate-id",
+				Name:         "client-1",
+				RedirectURIs: "https://example.com/callback",
+			},
+			wantError: false,
+			expectID:  false,
+		},
+	}
+
+	setup := testhelpers.SetupTestDB(t)
+	defer setup.Cleanup()
+
+	svc := NewOAuthService(setup.DB)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			created, err := svc.CreateClient(tt.client)
+			if tt.wantError {
+				testhelpers.AssertError(t, err)
+				return
+			}
+			testhelpers.AssertNoError(t, err)
+			testhelpers.AssertNotNil(t, created)
+			testhelpers.AssertEqual(t, tt.client.Name, created.Name)
+			testhelpers.AssertEqual(t, tt.client.RedirectURIs, created.RedirectURIs)
+			if tt.expectID && created.ClientID == "" {
+				t.Error("Expected ClientID to be auto-generated")
+			}
+		})
+	}
+
+	// Test duplicate client ID
+	client2 := &model.OAuthClient{
+		ClientID:     "duplicate-id",
+		Name:         "client-2",
+		RedirectURIs: "https://example.com/callback",
+	}
+	_, err := svc.CreateClient(client2)
+	testhelpers.AssertError(t, err)
+}
+
+func TestCreateAuthorizeCode(t *testing.T) {
+	tests := []struct {
+		name                string
+		clientID            string
+		redirectURI         string
+		scope               string
+		codeChallenge       string
+		codeChallengeMethod string
+		wantPKCE            bool
+	}{
+		{
+			name:                "without PKCE",
+			clientID:            "test-client-id",
+			redirectURI:         "https://example.com/callback",
+			scope:               "mcp",
+			codeChallenge:       "",
+			codeChallengeMethod: "",
+			wantPKCE:            false,
+		},
+		{
+			name:                "with PKCE S256",
+			clientID:            "test-client-id",
+			redirectURI:         "https://example.com/callback",
+			scope:               "mcp",
+			codeChallenge:       "Bhy6PJ1TNLW8pgFd6JIYMXgzl0akTrq2oHTvPqtPkBM",
+			codeChallengeMethod: "S256",
+			wantPKCE:            true,
+		},
+	}
+
+	setup := testhelpers.SetupTestDB(t)
+	defer setup.Cleanup()
+
+	svc := NewOAuthService(setup.DB)
+
+	user := &model.User{
+		Username:    "testuser",
+		AccessToken: "test-token-123",
+	}
+	setup.DB.Create(user)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, err := svc.CreateAuthorizeCode(
+				context.Background(),
+				tt.clientID,
+				user.ID,
+				tt.redirectURI,
+				tt.scope,
+				tt.codeChallenge,
+				tt.codeChallengeMethod,
+			)
+			testhelpers.AssertNoError(t, err)
+			if code == "" {
+				t.Error("Expected authorization code to be generated")
+			}
+
+			var authCode model.OAuthCode
+			err = setup.DB.Where("code = ?", code).First(&authCode).Error
+			testhelpers.AssertNoError(t, err)
+			testhelpers.AssertEqual(t, tt.clientID, authCode.ClientID)
+			testhelpers.AssertEqual(t, user.ID, authCode.UserID)
+
+			if tt.wantPKCE {
+				testhelpers.AssertEqual(t, tt.codeChallenge, authCode.CodeChallenge)
+				testhelpers.AssertEqual(t, tt.codeChallengeMethod, authCode.CodeChallengeMethod)
+			}
+		})
+	}
+}
+
+func TestExchangeCodeForToken(t *testing.T) {
+	tests := []struct {
+		name          string
+		usePKCE       bool
+		codeVerifier  string
+		wrongVerifier bool
+		expireCode    bool
+		wantError     bool
+		expectedError error
+		description   string
+	}{
+		{
+			name:         "successful exchange without PKCE",
+			usePKCE:      false,
+			codeVerifier: "",
+			wantError:    false,
+		},
+		{
+			name:         "successful exchange with PKCE",
+			usePKCE:      true,
+			codeVerifier: "test-verifier-123",
+			wantError:    false,
+		},
+		{
+			name:          "PKCE verification failure",
+			usePKCE:       true,
+			codeVerifier:  "test-verifier-123",
+			wrongVerifier: true,
+			wantError:     true,
+		},
+		{
+			name:          "expired code",
+			usePKCE:       false,
+			codeVerifier:  "",
+			expireCode:    true,
+			wantError:     true,
+			expectedError: ErrExpiredCode,
+		},
+	}
+
+	setup := testhelpers.SetupTestDB(t)
+	defer setup.Cleanup()
+
+	svc := NewOAuthService(setup.DB)
+
+	user := &model.User{
+		Username:    "testuser",
+		AccessToken: "test-token-123",
+	}
+	setup.DB.Create(user)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var code string
+			var challenge string
+			var verifier string
+
+			if tt.usePKCE {
+				verifier = "test-verifier-123"
+				h := sha256.New()
+				h.Write([]byte(verifier))
+				challenge = base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(h.Sum(nil))
+			}
+
+			code, _ = svc.CreateAuthorizeCode(
+				context.Background(),
+				"test-client-id",
+				user.ID,
+				"https://example.com/callback",
+				"mcp",
+				challenge,
+				func() string {
+					if tt.usePKCE {
+						return "S256"
+					}
+					return ""
+				}(),
+			)
+
+			if tt.expireCode {
+				var authCode model.OAuthCode
+				setup.DB.Where("code = ?", code).First(&authCode)
+				authCode.ExpiresAt = time.Now().Add(-1 * time.Minute)
+				setup.DB.Save(&authCode)
+			}
+
+			exchangeVerifier := tt.codeVerifier
+			if tt.wrongVerifier {
+				exchangeVerifier = "wrong-verifier"
+			}
+
+			token, err := svc.ExchangeCodeForToken(code, "test-client-id", exchangeVerifier)
+
+			if tt.wantError {
+				testhelpers.AssertError(t, err)
+				if tt.expectedError != nil {
+					testhelpers.AssertEqual(t, tt.expectedError, err)
+				}
+				return
+			}
+
+			testhelpers.AssertNoError(t, err)
+			testhelpers.AssertNotNil(t, token)
+			if token.Token == "" {
+				t.Error("Expected access token to be generated")
+			}
+			if token.RefreshToken == "" {
+				t.Error("Expected refresh token to be generated")
+			}
+			testhelpers.AssertEqual(t, user.ID, token.UserID)
+			testhelpers.AssertEqual(t, "test-client-id", token.ClientID)
+
+			// Verify code was deleted (one-time use)
+			var authCode model.OAuthCode
+			err = setup.DB.Where("code = ?", code).First(&authCode).Error
+			if err == nil {
+				t.Error("Expected authorization code to be deleted after exchange")
+			}
+		})
+	}
+}
+
+func TestGetTokenByValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		expireToken bool
+		wantError   bool
+	}{
+		{
+			name:        "valid token",
+			expireToken: false,
+			wantError:   false,
+		},
+		{
+			name:        "expired token",
+			expireToken: true,
+			wantError:   true,
+		},
+	}
+
+	setup := testhelpers.SetupTestDB(t)
+	defer setup.Cleanup()
+
+	svc := NewOAuthService(setup.DB)
+
+	user := &model.User{
+		Username:    "testuser",
+		AccessToken: "test-token-123",
+	}
+	setup.DB.Create(user)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			code, _ := svc.CreateAuthorizeCode(
+				context.Background(),
+				"test-client-id",
+				user.ID,
+				"https://example.com/callback",
+				"mcp",
+				"",
+				"",
+			)
+			token, _ := svc.ExchangeCodeForToken(code, "test-client-id", "")
+
+			if tt.expireToken {
+				var oauthToken model.OAuthToken
+				setup.DB.Where("token = ?", token.Token).First(&oauthToken)
+				oauthToken.ExpiresAt = time.Now().Add(-1 * time.Hour)
+				setup.DB.Save(&oauthToken)
+			}
+
+			retrieved, err := svc.GetTokenByValue(token.Token)
+
+			if tt.wantError {
+				testhelpers.AssertError(t, err)
+				return
+			}
+
+			testhelpers.AssertNoError(t, err)
+			testhelpers.AssertNotNil(t, retrieved)
+			testhelpers.AssertEqual(t, token.Token, retrieved.Token)
+			testhelpers.AssertEqual(t, token.UserID, retrieved.UserID)
+		})
+	}
+}
+
+func TestVerifyPKCE(t *testing.T) {
+	verifier := "test-verifier-123"
+	h := sha256.New()
+	h.Write([]byte(verifier))
+	s256Challenge := base64.URLEncoding.WithPadding(base64.NoPadding).EncodeToString(h.Sum(nil))
+
+	tests := []struct {
+		name      string
+		challenge string
+		method    string
+		verifier  string
+		want      bool
+	}{
+		{
+			name:      "S256 with correct verifier",
+			challenge: s256Challenge,
+			method:    "S256",
+			verifier:  verifier,
+			want:      true,
+		},
+		{
+			name:      "S256 with wrong verifier",
+			challenge: s256Challenge,
+			method:    "S256",
+			verifier:  "wrong-verifier",
+			want:      false,
+		},
+		{
+			name:      "plain with matching challenge",
+			challenge: "plain-challenge",
+			method:    "plain",
+			verifier:  "plain-challenge",
+			want:      true,
+		},
+		{
+			name:      "plain with non-matching challenge",
+			challenge: "plain-challenge",
+			method:    "plain",
+			verifier:  "wrong-challenge",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := verifyPKCE(tt.challenge, tt.method, tt.verifier)
+			if got != tt.want {
+				t.Errorf("verifyPKCE() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/testhelpers/testhelpers.go
+++ b/pkg/testhelpers/testhelpers.go
@@ -217,6 +217,9 @@ func SetupTestDB(t *testing.T) *TestDBSetup {
 		&model.ServerConfig{},
 		&model.ToolGroup{},
 		&model.Prompt{},
+		&model.OAuthClient{},
+		&model.OAuthCode{},
+		&model.OAuthToken{},
 	)
 	AssertNoError(t, err)
 

--- a/pkg/types/oauth.go
+++ b/pkg/types/oauth.go
@@ -1,0 +1,19 @@
+package types
+
+// OAuthClient represents an OAuth 2.0 client configuration for creation
+type OAuthClient struct {
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
+	Name         string `json:"name"`
+	RedirectURIs string `json:"redirect_uris"`
+	Description  string `json:"description"`
+}
+
+// CreateOAuthClientRequest is the request body for creating an OAuth client
+type CreateOAuthClientRequest struct {
+	Name         string `json:"name"`
+	RedirectURIs string `json:"redirect_uris"`
+	Description  string `json:"description,omitempty"`
+	ClientID     string `json:"client_id,omitempty"`
+	ClientSecret string `json:"client_secret,omitempty"`
+}

--- a/scripts/test-mcpjungle.sh
+++ b/scripts/test-mcpjungle.sh
@@ -204,7 +204,16 @@ else
   log "⚠️  Times similar (MCP server may have fast startup)"
 fi
 
-# 9) Print Homebrew formula config snippet
+# 9) Test OAuth 2.0 endpoints
+log "Testing OAuth 2.0 endpoints"
+curl -fsS "$LOCAL_REGISTRY/.well-known/openid-configuration" | grep -q "issuer" || { log "ERROR: OIDC discovery endpoint failed"; exit 1; }
+curl -fsS "$LOCAL_REGISTRY/.well-known/oauth-protected-resource" | grep -q "resource" || { log "ERROR: OAuth protected resource endpoint failed"; exit 1; }
+curl -fsS "$LOCAL_REGISTRY/oauth/authorize?client_id=test&redirect_uri=https://example.com/callback" | grep -q "Authorize MCPJungle" || { log "ERROR: Authorization endpoint failed"; exit 1; }
+TOKEN_RESPONSE=$(curl -s -X POST "$LOCAL_REGISTRY/oauth/token" -d "grant_type=invalid")
+echo "$TOKEN_RESPONSE" | grep -q "unsupported grant type" || { log "ERROR: Token endpoint validation failed. Response: $TOKEN_RESPONSE"; exit 1; }
+log "✅ OAuth endpoints working"
+
+# 10) Print Homebrew formula config snippet
 log "Homebrew formula config (from .goreleaser.yaml)"
 sed -n '/^brews:/,/^dockers:/p' "$ROOT_DIR/.goreleaser.yaml" || true
 popd >/dev/null


### PR DESCRIPTION
The API authentication middleware is updated so it can recognize OAuth access tokens sent in the Authorization: Bearer <token> header. Before this, the API only accepted fixed/static tokens. when a request comes in, the middleware now checks:

Is this a valid OAuth token?
Is it not expired?
Does it belong to a registered OAuth client and user?

If the token is valid, the request is allowed and the user is treated as authenticated. OAuth tokens work alongside existing authentication. This means: Old static tokens still work New OAuth-based clients (like ChatGPT) also work No breaking changes for existing users

Finally, the OAuth service is initialized when the server starts, so token validation is available everywhere the middleware runs.