### PR TITLE
feat(add prompts): add prompt support to tool groups

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -109,8 +109,28 @@ func runGetGroup(cmd *cobra.Command, args []string) error {
 	}
 	cmd.Println()
 
+	if len(group.IncludedPrompts) == 0 {
+		cmd.Println("Included Prompts: None")
+	} else {
+		cmd.Println("Included Prompts:")
+		for i, p := range group.IncludedPrompts {
+			cmd.Printf("%d. %s\n", i+1, p)
+		}
+	}
+	cmd.Println()
+
+	if len(group.ExcludedPrompts) == 0 {
+		cmd.Println("Excluded Prompts: None")
+	} else {
+		cmd.Println("Excluded Prompts:")
+		for i, p := range group.ExcludedPrompts {
+			cmd.Printf("%d. %s\n", i+1, p)
+		}
+	}
+	cmd.Println()
+
 	cmd.Println(
-		"NOTE: If a tool in this group is disabled globally or has been deleted, " +
+		"NOTE: If a tool or prompt in this group is disabled globally or has been deleted, " +
 			"then it will not be available via the group's MCP endpoint.",
 	)
 

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -103,15 +103,21 @@ func runUpdateGroup(cmd *cobra.Command, args []string) error {
 	}
 
 	// Check if anything was actually changed
-	toolsAdded, toolsRemoved := util.DiffTools(resp.Old.IncludedTools, resp.New.IncludedTools)
-	serversAdded, serversRemoved := util.DiffTools(resp.Old.IncludedServers, resp.New.IncludedServers)
-	excludedAdded, excludedRemoved := util.DiffTools(resp.Old.ExcludedTools, resp.New.ExcludedTools)
+	toolsAdded, toolsRemoved := util.DiffItems(resp.Old.IncludedTools, resp.New.IncludedTools)
+	serversAdded, serversRemoved := util.DiffItems(resp.Old.IncludedServers, resp.New.IncludedServers)
+	excludedToolsAdded, excludedToolsRemoved := util.DiffItems(resp.Old.ExcludedTools, resp.New.ExcludedTools)
+	promptsAdded, promptsRemoved := util.DiffItems(resp.Old.IncludedPrompts, resp.New.IncludedPrompts)
+	excludedPromptsAdded, excludedPromptsRemoved := util.DiffItems(resp.Old.ExcludedPrompts, resp.New.ExcludedPrompts)
 
 	noChangeInTools := len(toolsAdded) == 0 && len(toolsRemoved) == 0
 	noChangeInServers := len(serversAdded) == 0 && len(serversRemoved) == 0
-	noChangeInExcluded := len(excludedAdded) == 0 && len(excludedRemoved) == 0
+	noChangeInExcludedTools := len(excludedToolsAdded) == 0 && len(excludedToolsRemoved) == 0
+	noChangeInPrompts := len(promptsAdded) == 0 && len(promptsRemoved) == 0
+	noChangeInExcludedPrompts := len(excludedPromptsAdded) == 0 && len(excludedPromptsRemoved) == 0
 
-	if resp.Old.Description == resp.New.Description && noChangeInTools && noChangeInServers && noChangeInExcluded {
+	if resp.Old.Description == resp.New.Description &&
+		noChangeInTools && noChangeInServers && noChangeInExcludedTools &&
+		noChangeInPrompts && noChangeInExcludedPrompts {
 		cmd.Printf("No changes detected for Tool Group %s. Nothing was updated.\n", resp.Name)
 		return nil
 	}
@@ -159,17 +165,51 @@ func runUpdateGroup(cmd *cobra.Command, args []string) error {
 	}
 
 	// Report changes in excluded_tools
-	if !noChangeInExcluded {
-		if len(excludedRemoved) > 0 {
+	if !noChangeInExcludedTools {
+		if len(excludedToolsRemoved) > 0 {
 			cmd.Println("* Tools removed from excluded_tools:")
-			for _, e := range excludedRemoved {
+			for _, e := range excludedToolsRemoved {
 				cmd.Printf("    - %s\n", e)
 			}
 		}
-		if len(excludedAdded) > 0 {
+		if len(excludedToolsAdded) > 0 {
 			cmd.Println("* Tools added to excluded_tools:")
-			for _, e := range excludedAdded {
+			for _, e := range excludedToolsAdded {
 				cmd.Printf("    - %s\n", e)
+			}
+		}
+		cmd.Println()
+	}
+
+	// Report changes in included_prompts
+	if !noChangeInPrompts {
+		if len(promptsRemoved) > 0 {
+			cmd.Println("* Prompts removed from included_prompts:")
+			for _, p := range promptsRemoved {
+				cmd.Printf("    - %s\n", p)
+			}
+		}
+		if len(promptsAdded) > 0 {
+			cmd.Println("* Prompts added to included_prompts:")
+			for _, p := range promptsAdded {
+				cmd.Printf("    - %s\n", p)
+			}
+		}
+		cmd.Println()
+	}
+
+	// Report changes in excluded_prompts
+	if !noChangeInExcludedPrompts {
+		if len(excludedPromptsRemoved) > 0 {
+			cmd.Println("* Prompts removed from excluded_prompts:")
+			for _, p := range excludedPromptsRemoved {
+				cmd.Printf("    - %s\n", p)
+			}
+		}
+		if len(excludedPromptsAdded) > 0 {
+			cmd.Println("* Prompts added to excluded_prompts:")
+			for _, p := range excludedPromptsAdded {
+				cmd.Printf("    - %s\n", p)
 			}
 		}
 		cmd.Println()

--- a/internal/api/tool_groups.go
+++ b/internal/api/tool_groups.go
@@ -43,40 +43,15 @@ func (s *Server) listToolGroupsHandler() gin.HandlerFunc {
 
 		resp := make([]*types.ToolGroup, len(groups))
 		for i, g := range groups {
-			resp[i] = &types.ToolGroup{
-				Name:        g.Name,
-				Description: g.Description,
-			}
-
-			gTools, err := g.GetTools()
+			toolGroup, err := mapModelToTypesToolGroup(&g)
 			if err != nil {
 				c.JSON(
 					http.StatusInternalServerError,
-					gin.H{"error": fmt.Sprintf("error getting included tools of group %s: %s", g.Name, err.Error())},
+					gin.H{"error": fmt.Sprintf("group %s: %s", g.Name, err.Error())},
 				)
 				return
 			}
-			resp[i].IncludedTools = gTools
-
-			gServers, err := g.GetServers()
-			if err != nil {
-				c.JSON(
-					http.StatusInternalServerError,
-					gin.H{"error": fmt.Sprintf("error getting included servers of group %s: %s", g.Name, err.Error())},
-				)
-				return
-			}
-			resp[i].IncludedServers = gServers
-
-			gExcluded, err := g.GetExcludedTools()
-			if err != nil {
-				c.JSON(
-					http.StatusInternalServerError,
-					gin.H{"error": fmt.Sprintf("error getting excluded tools of group %s: %s", g.Name, err.Error())},
-				)
-				return
-			}
-			resp[i].ExcludedTools = gExcluded
+			resp[i] = toolGroup
 		}
 
 		c.JSON(http.StatusOK, resp)
@@ -101,49 +76,19 @@ func (s *Server) getToolGroupHandler() gin.HandlerFunc {
 			return
 		}
 
+		toolGroup, err := mapModelToTypesToolGroup(group)
+		if err != nil {
+			c.JSON(
+				http.StatusInternalServerError,
+				gin.H{"error": fmt.Sprintf("group %s: %s", name, err.Error())},
+			)
+			return
+		}
+
 		resp := &types.GetToolGroupResponse{
-			ToolGroup: &types.ToolGroup{
-				Name:        group.Name,
-				Description: group.Description,
-			},
+			ToolGroup:          toolGroup,
 			ToolGroupEndpoints: getToolGroupEndpoints(c, group.Name),
 		}
-
-		// Get included tools
-		var tools []string
-		tools, err = group.GetTools()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting included tools of group: %s", err.Error())},
-			)
-			return
-		}
-		resp.IncludedTools = tools
-
-		// Get included servers
-		var servers []string
-		servers, err = group.GetServers()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting included servers of group: %s", err.Error())},
-			)
-			return
-		}
-		resp.IncludedServers = servers
-
-		// Get excluded tools
-		var excludedTools []string
-		excludedTools, err = group.GetExcludedTools()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting excluded tools of group: %s", err.Error())},
-			)
-			return
-		}
-		resp.ExcludedTools = excludedTools
 
 		c.JSON(http.StatusOK, resp)
 	}
@@ -194,84 +139,29 @@ func (s *Server) updateToolGroupHandler() gin.HandlerFunc {
 			return
 		}
 
-		// create and send response object
+		oldToolGroup, err := mapModelToTypesToolGroup(originalConf)
+		if err != nil {
+			c.JSON(
+				http.StatusInternalServerError,
+				gin.H{"error": fmt.Sprintf("error mapping original group config: %s", err.Error())},
+			)
+			return
+		}
+
+		newToolGroup, err := mapModelToTypesToolGroup(&input)
+		if err != nil {
+			c.JSON(
+				http.StatusInternalServerError,
+				gin.H{"error": fmt.Sprintf("error mapping new group config: %s", err.Error())},
+			)
+			return
+		}
+
 		resp := &types.UpdateToolGroupResponse{
 			Name: name,
-			Old: &types.ToolGroup{
-				Name:        originalConf.Name,
-				Description: originalConf.Description,
-			},
-			New: &types.ToolGroup{
-				Name:        input.Name,
-				Description: input.Description,
-			},
+			Old:  oldToolGroup,
+			New:  newToolGroup,
 		}
-
-		var origTools []string
-		origTools, err = originalConf.GetTools()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting included tools of the original group config: %s", err.Error())},
-			)
-			return
-		}
-		resp.Old.IncludedTools = origTools
-
-		var origServers []string
-		origServers, err = originalConf.GetServers()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting included servers of the original group config: %s", err.Error())},
-			)
-			return
-		}
-		resp.Old.IncludedServers = origServers
-
-		var origExcluded []string
-		origExcluded, err = originalConf.GetExcludedTools()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting excluded tools of the original group config: %s", err.Error())},
-			)
-			return
-		}
-		resp.Old.ExcludedTools = origExcluded
-
-		var newTools []string
-		newTools, err = input.GetTools()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting included tools of the new group config: %s", err.Error())},
-			)
-			return
-		}
-		resp.New.IncludedTools = newTools
-
-		var newServers []string
-		newServers, err = input.GetServers()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting included servers of the new group config: %s", err.Error())},
-			)
-			return
-		}
-		resp.New.IncludedServers = newServers
-
-		var newExcluded []string
-		newExcluded, err = input.GetExcludedTools()
-		if err != nil {
-			c.JSON(
-				http.StatusInternalServerError,
-				gin.H{"error": fmt.Sprintf("error getting excluded tools of the new group config: %s", err.Error())},
-			)
-			return
-		}
-		resp.New.ExcludedTools = newExcluded
 
 		c.JSON(http.StatusOK, resp)
 	}
@@ -361,6 +251,47 @@ func (s *Server) toolGroupSseMCPServerCallMessageHandler() gin.HandlerFunc {
 
 		groupSseMcpServer.MessageHandler().ServeHTTP(c.Writer, c.Request)
 	}
+}
+
+// mapModelToTypesToolGroup converts a model.ToolGroup to types.ToolGroup.
+// This centralizes the mapping logic used by listToolGroupsHandler, getToolGroupHandler, etc.
+func mapModelToTypesToolGroup(g *model.ToolGroup) (*types.ToolGroup, error) {
+	result := &types.ToolGroup{
+		Name:        g.Name,
+		Description: g.Description,
+	}
+
+	tools, err := g.GetTools()
+	if err != nil {
+		return nil, fmt.Errorf("error getting included tools: %w", err)
+	}
+	result.IncludedTools = tools
+
+	servers, err := g.GetServers()
+	if err != nil {
+		return nil, fmt.Errorf("error getting included servers: %w", err)
+	}
+	result.IncludedServers = servers
+
+	excludedTools, err := g.GetExcludedTools()
+	if err != nil {
+		return nil, fmt.Errorf("error getting excluded tools: %w", err)
+	}
+	result.ExcludedTools = excludedTools
+
+	prompts, err := g.GetPrompts()
+	if err != nil {
+		return nil, fmt.Errorf("error getting included prompts: %w", err)
+	}
+	result.IncludedPrompts = prompts
+
+	excludedPrompts, err := g.GetExcludedPrompts()
+	if err != nil {
+		return nil, fmt.Errorf("error getting excluded prompts: %w", err)
+	}
+	result.ExcludedPrompts = excludedPrompts
+
+	return result, nil
 }
 
 // getToolGroupEndpoints deduces the proxy MCP server endpoint URLs for a given tool group.

--- a/internal/model/tool_group.go
+++ b/internal/model/tool_group.go
@@ -14,6 +14,12 @@ type ToolResolver interface {
 	ListToolsByServer(serverName string) ([]Tool, error)
 }
 
+// PromptResolver defines the interface needed to resolve prompts by server.
+type PromptResolver interface {
+	// ListPromptsByServer returns a list of prompts for the given MCP server name.
+	ListPromptsByServer(serverName string) ([]Prompt, error)
+}
+
 // ToolGroup represents a group of tools.
 // It is useful when the user wants to expose only a subset of all tools to MCP clients.
 type ToolGroup struct {
@@ -26,11 +32,18 @@ type ToolGroup struct {
 	// storing the list of tool names as a JSON array is a convenient way for now.
 	IncludedTools datatypes.JSON `json:"included_tools" gorm:"type:jsonb"`
 
+	// IncludedTools contains a list of tool names that are included in this group.
+	// storing the list of tool names as a JSON array is a convenient way for now.
+	IncludedPrompts datatypes.JSON `json:"included_prompts" gorm:"type:jsonb"`
+
 	// IncludedServers contains a list of MCP server names. All tools from these servers will be included.
 	IncludedServers datatypes.JSON `json:"included_servers" gorm:"type:jsonb"`
 
 	// ExcludedTools contains a list of tool names to exclude from the group.
 	ExcludedTools datatypes.JSON `json:"excluded_tools" gorm:"type:jsonb"`
+
+	// ExcludedPrompts contains a list of prompt names to exclude from the group.
+	ExcludedPrompts datatypes.JSON `json:"excluded_prompts" gorm:"type:jsonb"`
 }
 
 // GetTools unmarshals the IncludedTools JSON array into a slice of strings.
@@ -41,6 +54,16 @@ func (g *ToolGroup) GetTools() ([]string, error) {
 	var tools []string
 	err := json.Unmarshal(g.IncludedTools, &tools)
 	return tools, err
+}
+
+// GetPrompts unmarshals the IncludedPrompts JSON array into a slice of strings.
+func (g *ToolGroup) GetPrompts() ([]string, error) {
+	if g.IncludedPrompts == nil {
+		return []string{}, nil
+	}
+	var prompts []string
+	err := json.Unmarshal(g.IncludedPrompts, &prompts)
+	return prompts, err
 }
 
 // GetServers unmarshals the IncludedServers JSON array into a slice of strings.
@@ -63,52 +86,116 @@ func (g *ToolGroup) GetExcludedTools() ([]string, error) {
 	return tools, err
 }
 
-// ResolveEffectiveTools resolves all effective tools for this group by combining
-// included_tools, included_servers, and applying excluded_tools.
-// Note that tool exclusions are applied at last, so if a tool is both included and excluded,
-// it will be excluded.
-// It requires an MCP service to lookup tools by server.
-func (g *ToolGroup) ResolveEffectiveTools(mcpService ToolResolver) ([]string, error) {
-	effectiveTools := make(map[string]bool)
+// GetExcludedPrompts unmarshals the ExcludedPrompts JSON array into a slice of strings.
+func (g *ToolGroup) GetExcludedPrompts() ([]string, error) {
+	if g.ExcludedPrompts == nil {
+		return []string{}, nil
+	}
+	var prompts []string
+	err := json.Unmarshal(g.ExcludedPrompts, &prompts)
+	return prompts, err
+}
 
-	// Add tools from included_tools
-	includedTools, err := g.GetTools()
+// resolveEffective is a helper that resolves effective items by combining
+// included items, items from servers, and applying exclusions.
+// It uses functional composition to work with both tools and prompts.
+func (g *ToolGroup) resolveEffective(
+	getIncluded func() ([]string, error),
+	getExcluded func() ([]string, error),
+	getFromServer func(serverName string) ([]string, error),
+) ([]string, error) {
+	effective := make(map[string]bool)
+
+	// Add directly included items
+	included, err := getIncluded()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get included tools: %w", err)
+		return nil, fmt.Errorf("failed to get included items: %w", err)
 	}
-	for _, tool := range includedTools {
-		effectiveTools[tool] = true
+	for _, item := range included {
+		effective[item] = true
 	}
 
-	// Add tools from included_servers
-	includedServers, err := g.GetServers()
+	// Add items from included servers
+	servers, err := g.GetServers()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get included servers: %w", err)
 	}
-	for _, serverName := range includedServers {
-		serverTools, err := mcpService.ListToolsByServer(serverName)
+	for _, serverName := range servers {
+		serverItems, err := getFromServer(serverName)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get tools for server %s: %w", serverName, err)
+			return nil, fmt.Errorf("failed to get items for server %s: %w", serverName, err)
 		}
-		for _, tool := range serverTools {
-			effectiveTools[tool.Name] = true
+		for _, item := range serverItems {
+			effective[item] = true
 		}
 	}
 
-	// Remove tools from excluded_tools
-	excludedTools, err := g.GetExcludedTools()
+	// Remove excluded items
+	excluded, err := getExcluded()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get excluded tools: %w", err)
+		return nil, fmt.Errorf("failed to get excluded items: %w", err)
 	}
-	for _, tool := range excludedTools {
-		delete(effectiveTools, tool)
+	for _, item := range excluded {
+		delete(effective, item)
 	}
 
 	// Convert map to slice
-	result := make([]string, 0, len(effectiveTools))
-	for tool := range effectiveTools {
-		result = append(result, tool)
+	result := make([]string, 0, len(effective))
+	for item := range effective {
+		result = append(result, item)
 	}
 
 	return result, nil
+}
+
+// ResolveEffectiveTools resolves all effective tools for this group by combining
+// included_tools, included_servers, and applying excluded_tools.
+// Note that exclusions are applied last, so if a tool is both included and excluded,
+// it will be excluded.
+func (g *ToolGroup) ResolveEffectiveTools(mcpService ToolResolver) ([]string, error) {
+	return g.resolveEffective(
+		g.GetTools,
+		g.GetExcludedTools,
+		g.resolveToolNames(mcpService),
+	)
+}
+
+func (g *ToolGroup) resolveToolNames(mcpService ToolResolver) func(serverName string) ([]string, error) {
+	return func(serverName string) ([]string, error) {
+		tools, err := mcpService.ListToolsByServer(serverName)
+		if err != nil {
+			return nil, err
+		}
+		names := make([]string, len(tools))
+		for i, t := range tools {
+			names[i] = t.Name
+		}
+		return names, nil
+	}
+}
+
+// ResolveEffectivePrompts resolves all effective prompts for this group by combining
+// included_prompts, included_servers, and applying excluded_prompts.
+// Note that exclusions are applied last, so if a prompt is both included and excluded,
+// it will be excluded.
+func (g *ToolGroup) ResolveEffectivePrompts(mcpService PromptResolver) ([]string, error) {
+	return g.resolveEffective(
+		g.GetPrompts,
+		g.GetExcludedPrompts,
+		g.resolvePromptNames(mcpService),
+	)
+}
+
+func (g *ToolGroup) resolvePromptNames(mcpService PromptResolver) func(serverName string) ([]string, error) {
+	return func(serverName string) ([]string, error) {
+		prompts, err := mcpService.ListPromptsByServer(serverName)
+		if err != nil {
+			return nil, err
+		}
+		names := make([]string, len(prompts))
+		for i, p := range prompts {
+			names[i] = p.Name
+		}
+		return names, nil
+	}
 }

--- a/internal/model/tool_group_test.go
+++ b/internal/model/tool_group_test.go
@@ -19,6 +19,18 @@ func (m *mockToolResolver) ListToolsByServer(serverName string) ([]Tool, error) 
 	return []Tool{}, nil
 }
 
+// mockPromptResolver implements PromptResolver for testing
+type mockPromptResolver struct {
+	serverPrompts map[string][]Prompt
+}
+
+func (m *mockPromptResolver) ListPromptsByServer(serverName string) ([]Prompt, error) {
+	if prompts, exists := m.serverPrompts[serverName]; exists {
+		return prompts, nil
+	}
+	return []Prompt{}, nil
+}
+
 func TestToolGroup_GetTools(t *testing.T) {
 	tools := []string{"tool1", "tool2"}
 	toolsJSON, _ := json.Marshal(tools)
@@ -283,5 +295,265 @@ func TestToolGroup_ResolveEffectiveTools_EmptyGroup(t *testing.T) {
 
 	if len(result) != 0 {
 		t.Errorf("Expected 0 tools for empty group, got %d", len(result))
+	}
+}
+
+func TestToolGroup_GetPrompts(t *testing.T) {
+	t.Run("with prompts", func(t *testing.T) {
+		prompts := []string{"prompt1", "prompt2"}
+		promptsJSON, _ := json.Marshal(prompts)
+
+		group := &ToolGroup{
+			IncludedPrompts: datatypes.JSON(promptsJSON),
+		}
+
+		result, err := group.GetPrompts()
+		if err != nil {
+			t.Fatalf("GetPrompts() failed: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("Expected 2 prompts, got %d", len(result))
+		}
+		if result[0] != "prompt1" || result[1] != "prompt2" {
+			t.Errorf("Expected [prompt1, prompt2], got %v", result)
+		}
+	})
+
+	t.Run("nil returns empty slice", func(t *testing.T) {
+		group := &ToolGroup{}
+
+		result, err := group.GetPrompts()
+		if err != nil {
+			t.Fatalf("GetPrompts() failed: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("Expected 0 prompts, got %d", len(result))
+		}
+	})
+}
+
+func TestToolGroup_GetExcludedPrompts(t *testing.T) {
+	t.Run("with excluded prompts", func(t *testing.T) {
+		prompts := []string{"excluded1", "excluded2"}
+		promptsJSON, _ := json.Marshal(prompts)
+
+		group := &ToolGroup{
+			ExcludedPrompts: datatypes.JSON(promptsJSON),
+		}
+
+		result, err := group.GetExcludedPrompts()
+		if err != nil {
+			t.Fatalf("GetExcludedPrompts() failed: %v", err)
+		}
+		if len(result) != 2 {
+			t.Errorf("Expected 2 excluded prompts, got %d", len(result))
+		}
+		if result[0] != "excluded1" || result[1] != "excluded2" {
+			t.Errorf("Expected [excluded1, excluded2], got %v", result)
+		}
+	})
+
+	t.Run("nil returns empty slice", func(t *testing.T) {
+		group := &ToolGroup{}
+
+		result, err := group.GetExcludedPrompts()
+		if err != nil {
+			t.Fatalf("GetExcludedPrompts() failed: %v", err)
+		}
+		if len(result) != 0 {
+			t.Errorf("Expected 0 excluded prompts, got %d", len(result))
+		}
+	})
+}
+
+func TestToolGroup_ResolveEffectivePrompts(t *testing.T) {
+	resolver := &mockPromptResolver{
+		serverPrompts: map[string][]Prompt{
+			"github": {
+				{Name: "github__code-review"},
+				{Name: "github__security-audit"},
+				{Name: "github__summarize"},
+			},
+			"slack": {
+				{Name: "slack__compose-message"},
+				{Name: "slack__daily-standup"},
+			},
+		},
+	}
+
+	t.Run("IncludedPrompts only", func(t *testing.T) {
+		prompts := []string{"manual__prompt1", "manual__prompt2"}
+		promptsJSON, _ := json.Marshal(prompts)
+
+		group := &ToolGroup{
+			IncludedPrompts: datatypes.JSON(promptsJSON),
+		}
+
+		result, err := group.ResolveEffectivePrompts(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectivePrompts() failed: %v", err)
+		}
+
+		if len(result) != 2 {
+			t.Errorf("Expected 2 prompts, got %d", len(result))
+		}
+
+		promptMap := make(map[string]bool)
+		for _, p := range result {
+			promptMap[p] = true
+		}
+		if !promptMap["manual__prompt1"] || !promptMap["manual__prompt2"] {
+			t.Errorf("Expected manual prompts, got %v", result)
+		}
+	})
+
+	t.Run("IncludedServers only", func(t *testing.T) {
+		servers := []string{"github"}
+		serversJSON, _ := json.Marshal(servers)
+
+		group := &ToolGroup{
+			IncludedServers: datatypes.JSON(serversJSON),
+		}
+
+		result, err := group.ResolveEffectivePrompts(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectivePrompts() failed: %v", err)
+		}
+
+		if len(result) != 3 {
+			t.Errorf("Expected 3 prompts from github server, got %d", len(result))
+		}
+
+		promptMap := make(map[string]bool)
+		for _, p := range result {
+			promptMap[p] = true
+		}
+		expected := []string{"github__code-review", "github__security-audit", "github__summarize"}
+		for _, e := range expected {
+			if !promptMap[e] {
+				t.Errorf("Expected prompt %s not found in result %v", e, result)
+			}
+		}
+	})
+
+	t.Run("IncludedServers with ExcludedPrompts", func(t *testing.T) {
+		servers := []string{"github", "slack"}
+		serversJSON, _ := json.Marshal(servers)
+
+		excluded := []string{"github__summarize", "slack__daily-standup"}
+		excludedJSON, _ := json.Marshal(excluded)
+
+		group := &ToolGroup{
+			IncludedServers: datatypes.JSON(serversJSON),
+			ExcludedPrompts: datatypes.JSON(excludedJSON),
+		}
+
+		result, err := group.ResolveEffectivePrompts(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectivePrompts() failed: %v", err)
+		}
+
+		if len(result) != 3 {
+			t.Errorf("Expected 3 prompts (5 from servers - 2 excluded), got %d", len(result))
+		}
+
+		promptMap := make(map[string]bool)
+		for _, p := range result {
+			promptMap[p] = true
+		}
+
+		expected := []string{"github__code-review", "github__security-audit", "slack__compose-message"}
+		for _, e := range expected {
+			if !promptMap[e] {
+				t.Errorf("Expected prompt %s not found in result %v", e, result)
+			}
+		}
+
+		unexpected := []string{"github__summarize", "slack__daily-standup"}
+		for _, u := range unexpected {
+			if promptMap[u] {
+				t.Errorf("Unexpected excluded prompt %s found in result %v", u, result)
+			}
+		}
+	})
+
+	t.Run("Mixed IncludedPrompts and IncludedServers with ExcludedPrompts", func(t *testing.T) {
+		prompts := []string{"manual__custom-prompt"}
+		promptsJSON, _ := json.Marshal(prompts)
+
+		servers := []string{"slack"}
+		serversJSON, _ := json.Marshal(servers)
+
+		excluded := []string{"slack__daily-standup"}
+		excludedJSON, _ := json.Marshal(excluded)
+
+		group := &ToolGroup{
+			IncludedPrompts: datatypes.JSON(promptsJSON),
+			IncludedServers: datatypes.JSON(serversJSON),
+			ExcludedPrompts: datatypes.JSON(excludedJSON),
+		}
+
+		result, err := group.ResolveEffectivePrompts(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectivePrompts() failed: %v", err)
+		}
+
+		if len(result) != 2 {
+			t.Errorf("Expected 2 prompts (1 manual + 2 from slack - 1 excluded), got %d", len(result))
+		}
+
+		promptMap := make(map[string]bool)
+		for _, p := range result {
+			promptMap[p] = true
+		}
+
+		if !promptMap["manual__custom-prompt"] || !promptMap["slack__compose-message"] {
+			t.Errorf("Expected manual and slack prompts, got %v", result)
+		}
+		if promptMap["slack__daily-standup"] {
+			t.Errorf("Unexpected excluded prompt slack__daily-standup found in result %v", result)
+		}
+	})
+
+	t.Run("Same prompt in IncludedPrompts and ExcludedPrompts", func(t *testing.T) {
+		prompts := []string{"manual__prompt1", "github__code-review"}
+		promptsJSON, _ := json.Marshal(prompts)
+
+		excluded := []string{"github__code-review"}
+		excludedJSON, _ := json.Marshal(excluded)
+
+		group := &ToolGroup{
+			IncludedPrompts: datatypes.JSON(promptsJSON),
+			ExcludedPrompts: datatypes.JSON(excludedJSON),
+		}
+
+		result, err := group.ResolveEffectivePrompts(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectivePrompts() failed: %v", err)
+		}
+
+		if len(result) != 1 {
+			t.Errorf("Expected 1 prompt (manual__prompt1), got %d", len(result))
+		}
+		if result[0] != "manual__prompt1" {
+			t.Errorf("Expected manual__prompt1, got %v", result)
+		}
+	})
+}
+
+func TestToolGroup_ResolveEffectivePrompts_EmptyGroup(t *testing.T) {
+	resolver := &mockPromptResolver{
+		serverPrompts: map[string][]Prompt{},
+	}
+
+	group := &ToolGroup{}
+
+	result, err := group.ResolveEffectivePrompts(resolver)
+	if err != nil {
+		t.Fatalf("ResolveEffectivePrompts() failed: %v", err)
+	}
+
+	if len(result) != 0 {
+		t.Errorf("Expected 0 prompts for empty group, got %d", len(result))
 	}
 }

--- a/internal/service/mcp/mcp.go
+++ b/internal/service/mcp/mcp.go
@@ -46,6 +46,13 @@ type MCPService struct {
 	// (registered or (re)enabled) in mcpjungle.
 	toolAdditionCallback ToolAdditionCallback
 
+	// promptDeletionCallback is a callback that gets invoked when one or more prompts is removed
+	// (deregistered or disabled) from mcpjungle.
+	promptDeletionCallback PromptDeletionCallback
+	// promptAdditionCallback is a callback that gets invoked when one or more prompts is added
+	// (registered or (re)enabled) in mcpjungle.
+	promptAdditionCallback PromptAdditionCallback
+
 	metrics telemetry.CustomMetrics
 
 	mcpServerInitReqTimeoutSec int
@@ -76,8 +83,10 @@ func NewMCPService(c *ServiceConfig) (*MCPService, error) {
 		mu:            sync.RWMutex{},
 
 		// initialize the callbacks to NOOP functions
-		toolDeletionCallback: func(toolNames ...string) {},
-		toolAdditionCallback: func(toolName string) error { return nil },
+		toolDeletionCallback:   func(toolNames ...string) {},
+		toolAdditionCallback:   func(toolName string) error { return nil },
+		promptDeletionCallback: func(promptNames ...string) {},
+		promptAdditionCallback: func(promptName string) error { return nil },
 
 		metrics: c.Metrics,
 

--- a/internal/service/mcp/mcp_test.go
+++ b/internal/service/mcp/mcp_test.go
@@ -63,6 +63,12 @@ func TestNewMCPService(t *testing.T) {
 				if mcpService.toolAdditionCallback == nil {
 					t.Error("Expected toolAdditionCallback to be initialized")
 				}
+				if mcpService.promptDeletionCallback == nil {
+					t.Error("Expected promptDeletionCallback to be initialized")
+				}
+				if mcpService.promptAdditionCallback == nil {
+					t.Error("Expected promptAdditionCallback to be initialized")
+				}
 			}
 		})
 	}
@@ -101,6 +107,12 @@ func TestMCPServiceInitialization(t *testing.T) {
 	if mcpService.toolAdditionCallback == nil {
 		t.Error("Expected toolAdditionCallback to be initialized")
 	}
+	if mcpService.promptDeletionCallback == nil {
+		t.Error("Expected promptDeletionCallback to be initialized")
+	}
+	if mcpService.promptAdditionCallback == nil {
+		t.Error("Expected promptAdditionCallback to be initialized")
+	}
 }
 
 func TestMCPServiceCallbacks(t *testing.T) {
@@ -136,6 +148,63 @@ func TestMCPServiceCallbacks(t *testing.T) {
 
 	err = mcpService.toolAdditionCallback("tool1")
 	testhelpers.AssertNoError(t, err)
+
+	// Test that prompt callbacks are initialized to NOOP functions
+	func() {
+		defer func() {
+			if r := recover(); r != nil {
+				t.Errorf("Expected no panic from promptDeletionCallback, but got: %v", r)
+			}
+		}()
+		mcpService.promptDeletionCallback("prompt1", "prompt2")
+	}()
+
+	err = mcpService.promptAdditionCallback("prompt1")
+	testhelpers.AssertNoError(t, err)
+}
+
+func TestMCPServiceSetPromptCallbacks(t *testing.T) {
+	db, err := testhelpers.CreateTestDB()
+	testhelpers.AssertNoError(t, err)
+
+	err = db.AutoMigrate(&model.McpServer{}, &model.Tool{}, &model.Prompt{})
+	testhelpers.AssertNoError(t, err)
+
+	proxyServer := &server.MCPServer{}
+
+	conf := &ServiceConfig{
+		DB:                      db,
+		McpProxyServer:          proxyServer,
+		SseMcpProxyServer:       proxyServer,
+		Metrics:                 telemetry.NewNoopCustomMetrics(),
+		McpServerInitReqTimeout: 10,
+	}
+	mcpService, err := NewMCPService(conf)
+	testhelpers.AssertNoError(t, err)
+
+	t.Run("set_prompt_deletion_callback", func(t *testing.T) {
+		var deletedPrompts []string
+		mcpService.SetPromptDeletionCallback(func(promptNames ...string) {
+			deletedPrompts = append(deletedPrompts, promptNames...)
+		})
+
+		mcpService.promptDeletionCallback("p1", "p2")
+		testhelpers.AssertEqual(t, 2, len(deletedPrompts))
+		testhelpers.AssertEqual(t, "p1", deletedPrompts[0])
+		testhelpers.AssertEqual(t, "p2", deletedPrompts[1])
+	})
+
+	t.Run("set_prompt_addition_callback", func(t *testing.T) {
+		var addedPrompt string
+		mcpService.SetPromptAdditionCallback(func(promptName string) error {
+			addedPrompt = promptName
+			return nil
+		})
+
+		err := mcpService.promptAdditionCallback("p1")
+		testhelpers.AssertNoError(t, err)
+		testhelpers.AssertEqual(t, "p1", addedPrompt)
+	})
 }
 
 func TestMCPServiceConcurrency(t *testing.T) {

--- a/internal/service/mcp/prompt.go
+++ b/internal/service/mcp/prompt.go
@@ -12,6 +12,28 @@ import (
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 )
 
+// PromptDeletionCallback is a function type that can be registered to be called
+// whenever one or more prompts are deleted (deregistered) or disabled.
+// The callback receives the names of the deleted prompts as arguments.
+type PromptDeletionCallback func(promptNames ...string)
+
+// PromptAdditionCallback is a function type that can be registered to be called
+// whenever a prompt is added (registered or re-enabled).
+// The callback receives the name of the added prompt as argument.
+type PromptAdditionCallback func(promptName string) error
+
+// SetPromptDeletionCallback registers a callback function to be called
+// whenever one or more prompts are deleted (deregistered) or disabled.
+func (m *MCPService) SetPromptDeletionCallback(callback PromptDeletionCallback) {
+	m.promptDeletionCallback = callback
+}
+
+// SetPromptAdditionCallback registers a callback function to be called
+// whenever one or more prompts are added (registered or re-enabled).
+func (m *MCPService) SetPromptAdditionCallback(callback PromptAdditionCallback) {
+	m.promptAdditionCallback = callback
+}
+
 // ListPrompts returns all prompts registered in the registry.
 func (m *MCPService) ListPrompts() ([]model.Prompt, error) {
 	var prompts []model.Prompt
@@ -198,10 +220,11 @@ func (m *MCPService) setPromptsEnabled(entity string, enabled bool) ([]string, e
 			mcpPrompt.Name = entity
 
 			if s.Transport == types.TransportSSE {
-				m.sseMcpProxyServer.AddPrompt(mcpPrompt, m.mcpProxyPromptHandler)
+				m.sseMcpProxyServer.AddPrompt(mcpPrompt, m.MCPProxyPromptHandler)
 			} else {
-				m.mcpProxyServer.AddPrompt(mcpPrompt, m.mcpProxyPromptHandler)
+				m.mcpProxyServer.AddPrompt(mcpPrompt, m.MCPProxyPromptHandler)
 			}
+			m.notifyPromptAddition(entity)
 		} else {
 			// if the prompt was disabled, remove it from the MCP proxy server
 			if s.Transport == types.TransportSSE {
@@ -209,6 +232,7 @@ func (m *MCPService) setPromptsEnabled(entity string, enabled bool) ([]string, e
 			} else {
 				m.mcpProxyServer.DeletePrompts(entity)
 			}
+			m.notifyPromptDeletion(entity)
 		}
 
 		return []string{entity}, nil
@@ -246,16 +270,18 @@ func (m *MCPService) setPromptsEnabled(entity string, enabled bool) ([]string, e
 			mcpPrompt.Name = canonicalPromptName
 
 			if s.Transport == types.TransportSSE {
-				m.sseMcpProxyServer.AddPrompt(mcpPrompt, m.mcpProxyPromptHandler)
+				m.sseMcpProxyServer.AddPrompt(mcpPrompt, m.MCPProxyPromptHandler)
 			} else {
-				m.mcpProxyServer.AddPrompt(mcpPrompt, m.mcpProxyPromptHandler)
+				m.mcpProxyServer.AddPrompt(mcpPrompt, m.MCPProxyPromptHandler)
 			}
+			m.notifyPromptAddition(canonicalPromptName)
 		} else {
 			if s.Transport == types.TransportSSE {
 				m.sseMcpProxyServer.DeletePrompts(canonicalPromptName)
 			} else {
 				m.mcpProxyServer.DeletePrompts(canonicalPromptName)
 			}
+			m.notifyPromptDeletion(canonicalPromptName)
 		}
 
 		changedPromptNames = append(changedPromptNames, canonicalPromptName)
@@ -294,10 +320,11 @@ func (m *MCPService) registerServerPrompts(ctx context.Context, s *model.McpServ
 			prompt.Name = canonicalPromptName
 
 			if s.Transport == types.TransportSSE {
-				m.sseMcpProxyServer.AddPrompt(prompt, m.mcpProxyPromptHandler)
+				m.sseMcpProxyServer.AddPrompt(prompt, m.MCPProxyPromptHandler)
 			} else {
-				m.mcpProxyServer.AddPrompt(prompt, m.mcpProxyPromptHandler)
+				m.mcpProxyServer.AddPrompt(prompt, m.MCPProxyPromptHandler)
 			}
+			m.notifyPromptAddition(canonicalPromptName)
 		}
 	}
 	return nil
@@ -330,5 +357,47 @@ func (m *MCPService) deregisterServerPrompts(s *model.McpServer) error {
 		m.mcpProxyServer.DeletePrompts(promptNames...)
 	}
 
+	// notify any registered callbacks about the prompt deletion
+	m.notifyPromptDeletion(promptNames...)
+
 	return nil
+}
+
+// GetPromptInstance returns the mcp.Prompt instance for the given prompt name.
+// Returns the prompt instance and a boolean indicating if it was found.
+func (m *MCPService) GetPromptInstance(name string) (mcp.Prompt, bool) {
+	prompt, err := m.GetPrompt(name)
+	if err != nil || !prompt.Enabled {
+		return mcp.Prompt{}, false
+	}
+
+	mcpPrompt, err := convertPromptModelToMcpObject(prompt)
+	if err != nil {
+		return mcp.Prompt{}, false
+	}
+
+	return mcpPrompt, true
+}
+
+// GetToolParentServer returns the MCP server that provides the given tool.
+// The input name must be the canonical tool name, ie, it must contain the server name prefix (eg- "server__tool").
+func (m *MCPService) GetPromptParentServer(name string) (*model.McpServer, error) {
+	serverName, _, ok := splitServerPromptName(name)
+	if !ok {
+		return nil, fmt.Errorf("invalid input: prompt name does not contain a %s separator", serverPromptNameSep)
+	}
+	return m.GetMcpServer(serverName)
+}
+
+// notifyPromptDeletion calls all registered prompt deletion callbacks with the given prompt names.
+func (m *MCPService) notifyPromptDeletion(promptNames ...string) {
+	m.promptDeletionCallback(promptNames...)
+}
+
+// notifyPromptAddition calls all registered prompt addition callbacks with the given prompt name.
+// This method works on best-effort basis. If a callback fails, it logs the error but does not propagate it.
+func (m *MCPService) notifyPromptAddition(promptName string) {
+	if err := m.promptAdditionCallback(promptName); err != nil {
+		log.Printf("[ERROR] prompt addition callback failed for %s: %v", promptName, err)
+	}
 }

--- a/internal/service/mcp/prompt_test.go
+++ b/internal/service/mcp/prompt_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/mark3labs/mcp-go/mcp"
@@ -131,8 +132,10 @@ func TestEnableDisablePrompts(t *testing.T) {
 	)
 
 	service := &MCPService{
-		db:             db,
-		mcpProxyServer: mcpProxyServer,
+		db:                     db,
+		mcpProxyServer:         mcpProxyServer,
+		promptDeletionCallback: func(promptNames ...string) {},
+		promptAdditionCallback: func(promptName string) error { return nil },
 	}
 
 	srv := createTestServer(t, db)
@@ -174,8 +177,10 @@ func TestEnableDisableServerPrompts(t *testing.T) {
 	)
 
 	service := &MCPService{
-		db:             db,
-		mcpProxyServer: mcpProxyServer,
+		db:                     db,
+		mcpProxyServer:         mcpProxyServer,
+		promptDeletionCallback: func(promptNames ...string) {},
+		promptAdditionCallback: func(promptName string) error { return nil },
 	}
 
 	srv := createTestServer(t, db)
@@ -206,6 +211,161 @@ func TestEnableDisableServerPrompts(t *testing.T) {
 	for _, prompt := range prompts {
 		assert.True(t, prompt.Enabled)
 	}
+}
+
+func TestGetPromptInstance(t *testing.T) {
+	db := setupTestDBWithPrompts(t)
+	service := &MCPService{db: db}
+
+	srv := createTestServer(t, db)
+	createTestPrompt(t, db, srv, "code-review")
+
+	t.Run("found_enabled_prompt", func(t *testing.T) {
+		mcpPrompt, found := service.GetPromptInstance("test-server__code-review")
+		assert.True(t, found)
+		assert.Equal(t, "test-server__code-review", mcpPrompt.Name)
+		assert.Equal(t, "Test prompt for code review", mcpPrompt.Description)
+		assert.Len(t, mcpPrompt.Arguments, 1)
+	})
+
+	t.Run("not_found_nonexistent", func(t *testing.T) {
+		_, found := service.GetPromptInstance("test-server__nonexistent")
+		assert.False(t, found)
+	})
+
+	t.Run("not_found_invalid_name", func(t *testing.T) {
+		_, found := service.GetPromptInstance("no-separator")
+		assert.False(t, found)
+	})
+
+	t.Run("not_found_disabled_prompt", func(t *testing.T) {
+		// Disable the prompt directly in DB
+		db.Model(&model.Prompt{}).Where("name = ?", "code-review").Update("enabled", false)
+
+		_, found := service.GetPromptInstance("test-server__code-review")
+		assert.False(t, found)
+
+		// Re-enable for other tests
+		db.Model(&model.Prompt{}).Where("name = ?", "code-review").Update("enabled", true)
+	})
+}
+
+func TestGetPromptParentServer(t *testing.T) {
+	db := setupTestDBWithPrompts(t)
+	service := &MCPService{db: db}
+
+	createTestServer(t, db)
+
+	t.Run("valid_name_returns_server", func(t *testing.T) {
+		srv, err := service.GetPromptParentServer("test-server__code-review")
+		require.NoError(t, err)
+		assert.Equal(t, "test-server", srv.Name)
+	})
+
+	t.Run("invalid_name_no_separator", func(t *testing.T) {
+		_, err := service.GetPromptParentServer("invalid-name")
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "does not contain a __ separator")
+	})
+
+	t.Run("nonexistent_server", func(t *testing.T) {
+		_, err := service.GetPromptParentServer("nonexistent__prompt")
+		assert.Error(t, err)
+	})
+}
+
+func TestNotifyPromptAddition_ErrorIsLogged(t *testing.T) {
+	db := setupTestDBWithPrompts(t)
+
+	service := &MCPService{
+		db:                     db,
+		promptDeletionCallback: func(promptNames ...string) {},
+		promptAdditionCallback: func(promptName string) error {
+			return fmt.Errorf("simulated callback error")
+		},
+	}
+
+	// notifyPromptAddition should not panic even when callback returns error
+	assert.NotPanics(t, func() {
+		service.notifyPromptAddition("test-prompt")
+	})
+}
+
+func TestEnableDisablePrompts_CallbacksInvoked(t *testing.T) {
+	db := setupTestDBWithPrompts(t)
+
+	mcpProxyServer := server.NewMCPServer(
+		"Test Proxy",
+		"0.1.0",
+		server.WithPromptCapabilities(true),
+	)
+
+	var addedPrompts []string
+	var deletedPrompts []string
+
+	service := &MCPService{
+		db:             db,
+		mcpProxyServer: mcpProxyServer,
+		promptDeletionCallback: func(promptNames ...string) {
+			deletedPrompts = append(deletedPrompts, promptNames...)
+		},
+		promptAdditionCallback: func(promptName string) error {
+			addedPrompts = append(addedPrompts, promptName)
+			return nil
+		},
+	}
+
+	srv := createTestServer(t, db)
+	createTestPrompt(t, db, srv, "code-review")
+
+	// Disable should trigger deletion callback
+	_, err := service.DisablePrompts("test-server__code-review")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test-server__code-review"}, deletedPrompts)
+
+	// Enable should trigger addition callback
+	_, err = service.EnablePrompts("test-server__code-review")
+	require.NoError(t, err)
+	assert.Equal(t, []string{"test-server__code-review"}, addedPrompts)
+}
+
+func TestEnableDisableServerPrompts_CallbacksInvoked(t *testing.T) {
+	db := setupTestDBWithPrompts(t)
+
+	mcpProxyServer := server.NewMCPServer(
+		"Test Proxy",
+		"0.1.0",
+		server.WithPromptCapabilities(true),
+	)
+
+	var addedPrompts []string
+	var deletedPrompts []string
+
+	service := &MCPService{
+		db:             db,
+		mcpProxyServer: mcpProxyServer,
+		promptDeletionCallback: func(promptNames ...string) {
+			deletedPrompts = append(deletedPrompts, promptNames...)
+		},
+		promptAdditionCallback: func(promptName string) error {
+			addedPrompts = append(addedPrompts, promptName)
+			return nil
+		},
+	}
+
+	srv := createTestServer(t, db)
+	createTestPrompt(t, db, srv, "code-review")
+	createTestPrompt(t, db, srv, "security-audit")
+
+	// Disable by server name should trigger deletion callback for each prompt
+	_, err := service.DisablePrompts("test-server")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"test-server__code-review", "test-server__security-audit"}, deletedPrompts)
+
+	// Enable by server name should trigger addition callback for each prompt
+	_, err = service.EnablePrompts("test-server")
+	require.NoError(t, err)
+	assert.ElementsMatch(t, []string{"test-server__code-review", "test-server__security-audit"}, addedPrompts)
 }
 
 func TestMergeServerPromptNames(t *testing.T) {

--- a/internal/service/mcp/proxy.go
+++ b/internal/service/mcp/proxy.go
@@ -73,10 +73,10 @@ func (m *MCPService) MCPProxyToolCallHandler(ctx context.Context, request mcp.Ca
 	return res, err
 }
 
-// mcpProxyPromptHandler handles prompt requests for the MCP proxy server
+// MCPProxyPromptHandler handles prompt requests for the MCP proxy server
 // by forwarding the request to the appropriate upstream MCP server and
 // relaying the response back.
-func (m *MCPService) mcpProxyPromptHandler(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
+func (m *MCPService) MCPProxyPromptHandler(ctx context.Context, request mcp.GetPromptRequest) (*mcp.GetPromptResult, error) {
 	started := time.Now()
 	outcome := telemetry.PromptCallOutcomeSuccess
 
@@ -219,9 +219,9 @@ func (m *MCPService) initMCPProxyServer() error {
 		}
 
 		if server.Transport == types.TransportSSE {
-			m.sseMcpProxyServer.AddPrompt(prompt, m.mcpProxyPromptHandler)
+			m.sseMcpProxyServer.AddPrompt(prompt, m.MCPProxyPromptHandler)
 		} else {
-			m.mcpProxyServer.AddPrompt(prompt, m.mcpProxyPromptHandler)
+			m.mcpProxyServer.AddPrompt(prompt, m.MCPProxyPromptHandler)
 		}
 	}
 

--- a/internal/service/toolgroup/toolgroup.go
+++ b/internal/service/toolgroup/toolgroup.go
@@ -55,9 +55,11 @@ func NewToolGroupService(db *gorm.DB, mcpService *mcp.MCPService) (*ToolGroupSer
 		sseMcpServerMu: sync.RWMutex{},
 	}
 
-	// register callbacks with mcp service to be notified when a tool gets added/removed
+	// register callbacks with mcp service to be notified when tools/prompts get added/removed
 	mcpService.SetToolDeletionCallback(s.handleToolDeletion)
 	mcpService.SetToolAdditionCallback(s.handleToolAddition)
+	mcpService.SetPromptDeletionCallback(s.handlePromptDeletion)
+	mcpService.SetPromptAdditionCallback(s.handlePromptAddition)
 
 	if err := s.initToolGroupMCPServers(); err != nil {
 		return nil, fmt.Errorf("failed to initialize tool group MCP servers: %w", err)
@@ -87,6 +89,11 @@ func (s *ToolGroupService) CreateToolGroup(group *model.ToolGroup) error {
 		return errors.New("tool group must contain at least one tool after resolving servers and exclusions")
 	}
 
+	promptNames, err := group.ResolveEffectivePrompts(s.mcpService)
+	if err != nil {
+		return fmt.Errorf("failed to resolve prompts: %w", err)
+	}
+
 	// create the proxy MCP servers that expose only specified tools
 	mcpServer := s.newMCPServer(group.Name)
 	sseMcpServer := s.newSseMCPServer(group.Name)
@@ -109,6 +116,24 @@ func (s *ToolGroupService) CreateToolGroup(group *model.ToolGroup) error {
 			sseMcpServer.AddTool(tool, s.mcpService.MCPProxyToolCallHandler)
 		} else {
 			mcpServer.AddTool(tool, s.mcpService.MCPProxyToolCallHandler)
+		}
+	}
+
+	for _, name := range promptNames {
+		prompt, exists := s.mcpService.GetPromptInstance(name)
+		if !exists {
+			return fmt.Errorf("prompt %s does not exist or is disabled", name)
+		}
+
+		parentServer, err := s.mcpService.GetPromptParentServer(name)
+		if err != nil {
+			return fmt.Errorf("failed to get parent MCP server of the tool %s: %w", name, err)
+		}
+
+		if parentServer.Transport == types.TransportSSE {
+			sseMcpServer.AddPrompt(prompt, s.mcpService.MCPProxyPromptHandler)
+		} else {
+			mcpServer.AddPrompt(prompt, s.mcpService.MCPProxyPromptHandler)
 		}
 	}
 
@@ -146,11 +171,23 @@ func (s *ToolGroupService) UpdateToolGroup(name string, updatedGroup *model.Tool
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve effective tools of the updated group: %w", err)
 	}
+	toolsAdded, toolsRemoved := util.DiffItems(oldToolNames, updatedToolNames)
 
-	toolsAdded, toolsRemoved := util.DiffTools(oldToolNames, updatedToolNames)
+	// determine which prompts were added or removed from the group
+	oldPromptNames, err := oldGroup.ResolveEffectivePrompts(s.mcpService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve effective prompts of original group: %w", err)
+	}
+	updatedPromptNames, err := updatedGroup.ResolveEffectivePrompts(s.mcpService)
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve effective prompts of the updated group: %w", err)
+	}
+	promptsAdded, promptsRemoved := util.DiffItems(oldPromptNames, updatedPromptNames)
 
 	// if nothing was actually changed in the group, no need to proceed further
-	if updatedGroup.Description == oldGroup.Description && len(toolsAdded) == 0 && len(toolsRemoved) == 0 {
+	if updatedGroup.Description == oldGroup.Description &&
+		len(toolsAdded) == 0 && len(toolsRemoved) == 0 &&
+		len(promptsAdded) == 0 && len(promptsRemoved) == 0 {
 		return oldGroup, nil
 	}
 
@@ -165,50 +202,65 @@ func (s *ToolGroupService) UpdateToolGroup(name string, updatedGroup *model.Tool
 		return nil, fmt.Errorf("SSE MCP server for tool group %s does not exist", name)
 	}
 
-	// tools added to the group must be added to its MCP server instances
-	var sseToolsToAdd, normalToolsToAdd []mcpgo.Tool
-	for _, toolName := range toolsAdded {
-		tool, exists := s.mcpService.GetToolInstance(toolName)
-		if !exists {
-			return nil, fmt.Errorf("tool %s does not exist or is disabled", toolName)
-		}
-
-		parentServer, err := s.mcpService.GetToolParentServer(toolName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get parent MCP server of the tool %s: %w", toolName, err)
-		}
-
-		if parentServer.Transport == types.TransportSSE {
-			sseToolsToAdd = append(sseToolsToAdd, tool)
-		} else {
-			normalToolsToAdd = append(normalToolsToAdd, tool)
-		}
+	// partition tools by transport type
+	sseToolsToAdd, normalToolsToAdd, err := partitionItemsToAdd(
+		toolsAdded,
+		s.mcpService.GetToolInstance,
+		s.mcpService.GetToolParentServer,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to partition tools to add: %w", err)
 	}
 
-	// tools removed from the group must be removed from its MCP server instances
-	var sseToolsToRemove, normalToolsToRemove []string
-	for _, toolName := range toolsRemoved {
-		parentServer, err := s.mcpService.GetToolParentServer(toolName)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get parent MCP server of the tool %s: %w", toolName, err)
-		}
+	sseToolsToRemove, normalToolsToRemove, err := partitionNamesToRemove(
+		toolsRemoved,
+		s.mcpService.GetToolParentServer,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to partition tools to remove: %w", err)
+	}
 
-		if parentServer.Transport == types.TransportSSE {
-			sseToolsToRemove = append(sseToolsToRemove, toolName)
-		} else {
-			normalToolsToRemove = append(normalToolsToRemove, toolName)
-		}
+	// partition prompts by transport type
+	ssePromptsToAdd, normalPromptsToAdd, err := partitionItemsToAdd(
+		promptsAdded,
+		s.mcpService.GetPromptInstance,
+		s.mcpService.GetPromptParentServer,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to partition prompts to add: %w", err)
+	}
+
+	ssePromptsToRemove, normalPromptsToRemove, err := partitionNamesToRemove(
+		promptsRemoved,
+		s.mcpService.GetPromptParentServer,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to partition prompts to remove: %w", err)
 	}
 
 	// make all the changes together to avoid inconsistent state in case of errors
+	// remove tools
 	mcpServer.DeleteTools(normalToolsToRemove...)
 	sseMcpServer.DeleteTools(sseToolsToRemove...)
 
+	// remove prompts
+	mcpServer.DeletePrompts(normalPromptsToRemove...)
+	sseMcpServer.DeletePrompts(ssePromptsToRemove...)
+
+	// add tools
 	for _, tool := range normalToolsToAdd {
 		mcpServer.AddTool(tool, s.mcpService.MCPProxyToolCallHandler)
 	}
 	for _, tool := range sseToolsToAdd {
 		sseMcpServer.AddTool(tool, s.mcpService.MCPProxyToolCallHandler)
+	}
+
+	// add prompts
+	for _, prompt := range normalPromptsToAdd {
+		mcpServer.AddPrompt(prompt, s.mcpService.MCPProxyPromptHandler)
+	}
+	for _, prompt := range ssePromptsToAdd {
+		sseMcpServer.AddPrompt(prompt, s.mcpService.MCPProxyPromptHandler)
 	}
 
 	// as a final step, update the tool group record in the database
@@ -322,6 +374,88 @@ func (s *ToolGroupService) deleteToolGroupMCPServers(name string) {
 	delete(s.sseMcpServers, name)
 }
 
+// addItemsToServers is a helper that adds items (tools or prompts) to MCP servers based on transport type.
+// It uses functional composition to work with both tools and prompts.
+// Missing items are skipped (useful during init when items may not exist yet).
+func addItemsToServers[T any](
+	names []string,
+	mcpServer *server.MCPServer,
+	sseMcpServer *server.MCPServer,
+	getInstance func(name string) (T, bool),
+	getParentServer func(name string) (*model.McpServer, error),
+	addToServer func(srv *server.MCPServer, item T),
+) error {
+	for _, name := range names {
+		item, exists := getInstance(name)
+		if !exists {
+			// TODO: Add a warning log here.
+			continue
+		}
+
+		parentServer, err := getParentServer(name)
+		if err != nil {
+			return fmt.Errorf("failed to get parent MCP server of item %s: %w", name, err)
+		}
+
+		if parentServer.Transport == types.TransportSSE {
+			addToServer(sseMcpServer, item)
+		} else {
+			addToServer(mcpServer, item)
+		}
+	}
+	return nil
+}
+
+// partitionItemsToAdd partitions items to add into SSE and normal transport categories.
+// Returns (sseItems, normalItems, error).
+func partitionItemsToAdd[T any](
+	names []string,
+	getInstance func(name string) (T, bool),
+	getParentServer func(name string) (*model.McpServer, error),
+) ([]T, []T, error) {
+	var sseItems, normalItems []T
+	for _, name := range names {
+		item, exists := getInstance(name)
+		if !exists {
+			return nil, nil, fmt.Errorf("item %s does not exist or is disabled", name)
+		}
+
+		parentServer, err := getParentServer(name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get parent MCP server of item %s: %w", name, err)
+		}
+
+		if parentServer.Transport == types.TransportSSE {
+			sseItems = append(sseItems, item)
+		} else {
+			normalItems = append(normalItems, item)
+		}
+	}
+	return sseItems, normalItems, nil
+}
+
+// partitionNamesToRemove partitions item names to remove into SSE and normal transport categories.
+// Returns (sseNames, normalNames, error).
+func partitionNamesToRemove(
+	names []string,
+	getParentServer func(name string) (*model.McpServer, error),
+) ([]string, []string, error) {
+	var sseNames, normalNames []string
+	for _, name := range names {
+		parentServer, err := getParentServer(name)
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to get parent MCP server of item %s: %w", name, err)
+		}
+
+		if parentServer.Transport == types.TransportSSE {
+			sseNames = append(sseNames, name)
+		} else {
+			normalNames = append(normalNames, name)
+		}
+	}
+	return sseNames, normalNames, nil
+}
+
 // initToolGroupMCPServers initializes the MCP proxy servers for all existing tool groups in the database.
 // It initializes both the mcpServers and sseMcpServers.
 func (s *ToolGroupService) initToolGroupMCPServers() error {
@@ -337,28 +471,38 @@ func (s *ToolGroupService) initToolGroupMCPServers() error {
 		}
 		// TODO: Log a warning if a group has no tools, ie, len(toolNames) == 0
 
+		promptNames, err := group.ResolveEffectivePrompts(s.mcpService)
+		if err != nil {
+			return fmt.Errorf("failed to resolve prompts for group %s: %w", group.Name, err)
+		}
+
 		mcpServer := s.newMCPServer(group.Name)
 		sseMcpServer := s.newSseMCPServer(group.Name)
 
-		for _, name := range toolNames {
-			tool, exists := s.mcpService.GetToolInstance(name)
-			if !exists {
-				// it is possible that a tool group contains a tool that does not exist.
-				// this should not prevent server startup, so just skip instead of returning an error.
-				// TODO: Add a warning log here.
-				continue
-			}
+		// Add tools to servers (skip missing during init)
+		err = addItemsToServers(
+			toolNames, mcpServer, sseMcpServer,
+			s.mcpService.GetToolInstance,
+			s.mcpService.GetToolParentServer,
+			func(srv *server.MCPServer, tool mcpgo.Tool) {
+				srv.AddTool(tool, s.mcpService.MCPProxyToolCallHandler)
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to add tools for group %s: %w", group.Name, err)
+		}
 
-			parentServer, err := s.mcpService.GetToolParentServer(name)
-			if err != nil {
-				return fmt.Errorf("failed to get parent MCP server of the tool %s: %w", name, err)
-			}
-
-			if parentServer.Transport == types.TransportSSE {
-				sseMcpServer.AddTool(tool, s.mcpService.MCPProxyToolCallHandler)
-			} else {
-				mcpServer.AddTool(tool, s.mcpService.MCPProxyToolCallHandler)
-			}
+		// Add prompts to servers (skip missing during init)
+		err = addItemsToServers(
+			promptNames, mcpServer, sseMcpServer,
+			s.mcpService.GetPromptInstance,
+			s.mcpService.GetPromptParentServer,
+			func(srv *server.MCPServer, prompt mcpgo.Prompt) {
+				srv.AddPrompt(prompt, s.mcpService.MCPProxyPromptHandler)
+			},
+		)
+		if err != nil {
+			return fmt.Errorf("failed to add prompts for group %s: %w", group.Name, err)
 		}
 
 		s.addToolGroupMCPServer(group.Name, mcpServer)
@@ -444,6 +588,85 @@ func (s *ToolGroupService) handleToolAddition(newTool string) error {
 		mcpServer, exists := s.mcpServers[name]
 		if exists {
 			mcpServer.AddTool(newToolInstance, s.mcpService.MCPProxyToolCallHandler)
+		}
+	}
+
+	return nil
+}
+
+// handlePromptDeletion is a callback that is called when one or more prompts is deleted or disabled.
+// It removes the prompts from all tool group MCP proxy servers.
+func (s *ToolGroupService) handlePromptDeletion(prompts ...string) {
+	s.mcpServersMu.RLock()
+	defer s.mcpServersMu.RUnlock()
+
+	s.sseMcpServerMu.Lock()
+	defer s.sseMcpServerMu.Unlock()
+
+	for _, mcpServer := range s.mcpServers {
+		mcpServer.DeletePrompts(prompts...)
+	}
+
+	for _, sseMcpServer := range s.sseMcpServers {
+		sseMcpServer.DeletePrompts(prompts...)
+	}
+}
+
+// handlePromptAddition is a callback that is called when a prompt is added or (re)enabled in mcpjungle.
+// This callback adds the new prompt to MCP proxy servers of all groups that include it.
+func (s *ToolGroupService) handlePromptAddition(newPrompt string) error {
+	// get all tool groups from the database
+	groups, err := s.ListToolGroups()
+	if err != nil {
+		return fmt.Errorf("failed to list tool groups from DB: %w", err)
+	}
+
+	// find all groups that include the added prompt
+	groupsToUpdate := make([]string, 0, len(groups))
+	for i := range groups {
+		name := groups[i].Name
+		groupPrompts, err := groups[i].ResolveEffectivePrompts(s.mcpService)
+		if err != nil {
+			return fmt.Errorf("failed to resolve effective prompts for group %s: %w", name, err)
+		}
+		for _, p := range groupPrompts {
+			if p != newPrompt {
+				continue
+			}
+			groupsToUpdate = append(groupsToUpdate, name)
+			break
+		}
+	}
+
+	newPromptInstance, exists := s.mcpService.GetPromptInstance(newPrompt)
+	if !exists {
+		return fmt.Errorf("prompt instance %s does not exist", newPrompt)
+	}
+
+	parentServer, err := s.mcpService.GetPromptParentServer(newPrompt)
+	if err != nil {
+		return fmt.Errorf("failed to get parent MCP server of the prompt %s: %w", newPrompt, err)
+	}
+
+	// add the new prompt instance to all relevant MCP proxy servers
+	s.mcpServersMu.RLock()
+	defer s.mcpServersMu.RUnlock()
+
+	s.sseMcpServerMu.Lock()
+	defer s.sseMcpServerMu.Unlock()
+
+	for _, name := range groupsToUpdate {
+		if parentServer.Transport == types.TransportSSE {
+			sseMcpServer, exists := s.sseMcpServers[name]
+			if exists {
+				sseMcpServer.AddPrompt(newPromptInstance, s.mcpService.MCPProxyPromptHandler)
+			}
+			continue
+		}
+
+		mcpServer, exists := s.mcpServers[name]
+		if exists {
+			mcpServer.AddPrompt(newPromptInstance, s.mcpService.MCPProxyPromptHandler)
 		}
 	}
 

--- a/pkg/types/tool_group.go
+++ b/pkg/types/tool_group.go
@@ -9,10 +9,14 @@ type ToolGroup struct {
 	Name string `json:"name"`
 	// IncludedTools is a list of tools included in this group.
 	IncludedTools []string `json:"included_tools,omitempty"`
+	// IncludedPrompts is a list of prompts included in this group.
+	IncludedPrompts []string `json:"included_prompts,omitempty"`
 	// IncludedServers is a list of MCP server names. All tools from these servers will be included.
 	IncludedServers []string `json:"included_servers,omitempty"`
 	// ExcludedTools is a list of tools to exclude from the group (useful with IncludedServers).
 	ExcludedTools []string `json:"excluded_tools,omitempty"`
+	// ExcludedPrompts is a list of prompts to exclude from the group (useful with IncludedServers).
+	ExcludedPrompts []string `json:"excluded_prompts,omitempty"`
 
 	Description string `json:"description"`
 }

--- a/pkg/types/tool_group_test.go
+++ b/pkg/types/tool_group_test.go
@@ -79,6 +79,72 @@ func TestToolGroupJSONMarshalingWithNewFields(t *testing.T) {
 	}
 }
 
+func TestToolGroupJSONMarshalingWithPromptFields(t *testing.T) {
+	t.Parallel()
+
+	group := ToolGroup{
+		Name:            "prompt-group",
+		IncludedTools:   []string{"tool1"},
+		IncludedPrompts: []string{"server__prompt1", "server__prompt2"},
+		IncludedServers: []string{"server"},
+		ExcludedTools:   []string{"server__tool-x"},
+		ExcludedPrompts: []string{"server__prompt3"},
+		Description:     "Group with prompt fields",
+	}
+
+	data, err := json.Marshal(group)
+	if err != nil {
+		t.Fatalf("Failed to marshal ToolGroup: %v", err)
+	}
+
+	var unmarshaled ToolGroup
+	err = json.Unmarshal(data, &unmarshaled)
+	if err != nil {
+		t.Fatalf("Failed to unmarshal ToolGroup: %v", err)
+	}
+
+	if len(unmarshaled.IncludedPrompts) != 2 {
+		t.Errorf("Expected 2 IncludedPrompts, got %d", len(unmarshaled.IncludedPrompts))
+	}
+	if unmarshaled.IncludedPrompts[0] != "server__prompt1" || unmarshaled.IncludedPrompts[1] != "server__prompt2" {
+		t.Errorf("Expected IncludedPrompts [server__prompt1, server__prompt2], got %v", unmarshaled.IncludedPrompts)
+	}
+	if len(unmarshaled.ExcludedPrompts) != 1 || unmarshaled.ExcludedPrompts[0] != "server__prompt3" {
+		t.Errorf("Expected ExcludedPrompts [server__prompt3], got %v", unmarshaled.ExcludedPrompts)
+	}
+}
+
+func TestToolGroupJSONOmitsEmptyPromptFields(t *testing.T) {
+	t.Parallel()
+
+	group := ToolGroup{
+		Name:        "minimal-group",
+		Description: "No prompts",
+	}
+
+	data, err := json.Marshal(group)
+	if err != nil {
+		t.Fatalf("Failed to marshal ToolGroup: %v", err)
+	}
+
+	jsonStr := string(data)
+	if contains(jsonStr, "included_prompts") {
+		t.Errorf("Expected included_prompts to be omitted, got %s", jsonStr)
+	}
+	if contains(jsonStr, "excluded_prompts") {
+		t.Errorf("Expected excluded_prompts to be omitted, got %s", jsonStr)
+	}
+}
+
+func contains(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}
+
 func TestCreateToolGroupResponse(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -1,14 +1,14 @@
 package util
 
-// DiffTools detects which tools have been added and removed between two slices containing tool names.
-func DiffTools(oldTools, newTools []string) (added, removed []string) {
-	oldSet := make(map[string]struct{}, len(oldTools))
-	newSet := make(map[string]struct{}, len(newTools))
+// DiffItems detects which mcp items have been added and removed between two slices containing tool names.
+func DiffItems(oldItems, newItems []string) (added, removed []string) {
+	oldSet := make(map[string]struct{}, len(oldItems))
+	newSet := make(map[string]struct{}, len(newItems))
 
-	for _, t := range oldTools {
+	for _, t := range oldItems {
 		oldSet[t] = struct{}{}
 	}
-	for _, t := range newTools {
+	for _, t := range newItems {
 		newSet[t] = struct{}{}
 	}
 

--- a/pkg/util/util_test.go
+++ b/pkg/util/util_test.go
@@ -9,7 +9,7 @@ import (
 func TestDiffTools_NoChange(t *testing.T) {
 	old := []string{"a", "b", "c"}
 	newT := []string{"a", "b", "c"}
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	if len(added) != 0 || len(removed) != 0 {
 		t.Errorf("Expected no changes, got added=%v removed=%v", added, removed)
 	}
@@ -18,7 +18,7 @@ func TestDiffTools_NoChange(t *testing.T) {
 func TestDiffTools_OnlyAdded(t *testing.T) {
 	old := []string{"a", "b"}
 	newT := []string{"a", "b", "c", "d"}
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	expectedAdded := []string{"c", "d"}
 
 	// ensure order does not affect the test outcome
@@ -33,7 +33,7 @@ func TestDiffTools_OnlyAdded(t *testing.T) {
 func TestDiffTools_OnlyRemoved(t *testing.T) {
 	old := []string{"a", "b", "c"}
 	newT := []string{"a"}
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	expectedRemoved := []string{"b", "c"}
 
 	// ensure order does not affect the test outcome
@@ -48,7 +48,7 @@ func TestDiffTools_OnlyRemoved(t *testing.T) {
 func TestDiffTools_AddedAndRemoved(t *testing.T) {
 	old := []string{"a", "b", "c"}
 	newT := []string{"b", "d", "e"}
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	expectedAdded := []string{"d", "e"}
 	expectedRemoved := []string{"a", "c"}
 
@@ -66,7 +66,7 @@ func TestDiffTools_AddedAndRemoved(t *testing.T) {
 func TestDiffTools_EmptyOld(t *testing.T) {
 	var old []string
 	newT := []string{"x", "y"}
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	expectedAdded := []string{"x", "y"}
 
 	// ensure order does not affect the test outcome
@@ -81,7 +81,7 @@ func TestDiffTools_EmptyOld(t *testing.T) {
 func TestDiffTools_EmptyNew(t *testing.T) {
 	old := []string{"x", "y"}
 	var newT []string
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	expectedRemoved := []string{"x", "y"}
 
 	// ensure order does not affect the test outcome
@@ -96,7 +96,7 @@ func TestDiffTools_EmptyNew(t *testing.T) {
 func TestDiffTools_BothEmpty(t *testing.T) {
 	var old []string
 	var newT []string
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	if len(added) != 0 || len(removed) != 0 {
 		t.Errorf("Expected no changes, got added=%v removed=%v", added, removed)
 	}
@@ -105,7 +105,7 @@ func TestDiffTools_BothEmpty(t *testing.T) {
 func TestDiffTools_Duplicates(t *testing.T) {
 	old := []string{"a", "a", "b"}
 	newT := []string{"a", "b", "b", "c"}
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	expectedAdded := []string{"c"}
 	var expectedRemoved []string
 
@@ -123,7 +123,7 @@ func TestDiffTools_Duplicates(t *testing.T) {
 func TestDiffTools_OrderDoesNotMatter(t *testing.T) {
 	old := []string{"a", "b", "c"}
 	newT := []string{"c", "b", "a"}
-	added, removed := DiffTools(old, newT)
+	added, removed := DiffItems(old, newT)
 	if len(added) != 0 || len(removed) != 0 {
 		t.Errorf("Expected no changes, got added=%v removed=%v", added, removed)
 	}


### PR DESCRIPTION
Added prompt support for tool group. 

## New Functionality Verified

### 1. Tool Group Prompt Support
- Groups support `included_prompts` and `excluded_prompts` fields
- Prompts from `included_servers` are automatically included
- Exclusions override inclusions
- Prompts properly partitioned by transport type (SSE vs normal)

### 2. CLI `get group` Enhancement
- Displays "Included Prompts" section
- Displays "Excluded Prompts" section
- Note mentions both tools AND prompts

### 3. CLI `update group` Enhancement
- Reports "Prompts added to excluded_prompts"
- Reports "Prompts removed from excluded_prompts"
- Reports "Prompts added to included_prompts"
- Reports "Prompts removed from included_prompts"

### 4. Prompt Callbacks
- Disabling a prompt removes it from all groups' MCP servers
- Enabling a prompt adds it back to relevant groups

### 5. HTTP Endpoints
- Create/update/delete tool group 