### PR TITLE
Implement live configuration reload

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,55 @@ mcpjungle start
 
 This starts the main registry server and MCP gateway, accessible on port `8080` by default.
 
+### Auto-synced configuration directory
+
+MCPJungle can optionally manage entities from a configuration directory as desired state.
+
+By default, this feature is **disabled**.
+
+Enable it using either CLI flags or environment variables:
+
+```bash
+# enable sync
+mcpjungle start --config-sync
+
+# enable sync + custom directory
+mcpjungle start --config-sync --config-dir /path/to/configs
+
+# equivalent env vars
+export MCPJUNGLE_CONFIG_SYNC_ENABLED=true
+export MCPJUNGLE_CONFIG_DIR=~/.mcpjungle
+mcpjungle start
+```
+
+Default directory layout:
+
+```
+~/.mcpjungle/
+  mcp_servers/
+    calculator.json
+  mcp_clients/
+    claude-desktop.json
+  groups/
+    claude-tools.json
+  users/
+    analyst.json
+```
+
+Behavior:
+- Files represent the desired state for entities managed from this directory.
+- New file => create entity in MCPJungle.
+- Updated file => update entity in DB and live in-memory state.
+- Deleted file => delete corresponding managed entity from MCPJungle.
+- The server applies sync on startup and keeps syncing live while running.
+
+Important rules:
+- Only entities tracked as directory-managed are enforced by desired state; manually managed entities are otherwise left alone.
+- If a file is added for an existing manual entity, MCPJungle adopts it and starts managing it from the directory.
+- Invalid config files do not remove the last-good applied state. MCPJungle logs detailed errors and retries on future changes.
+- Admin user is never managed by config sync and must be managed manually.
+- Startup fails if sync is enabled and reconciliation finds errors/conflicts; detailed errors are logged.
+
 ### Shutting down
 It is important that the mcpjungle server shuts down gracefully to ensure proper cleanup.
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mcpjungle/mcpjungle/pkg/accesstoken"
 	"github.com/mcpjungle/mcpjungle/pkg/configfiles"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"github.com/spf13/cobra"
@@ -180,7 +181,10 @@ func runCreateMcpClient(cmd *cobra.Command, args []string) error {
 			Description: config.Description,
 			AllowList:   config.AllowMcpServers,
 		}
-		accessToken, err := config.AccessTokenRef.ResolveAccessToken(config.AccessToken)
+		accessToken, err := accesstoken.Resolve(accesstoken.Input{
+			Inline: config.AccessToken,
+			Ref:    config.AccessTokenRef,
+		})
 		if err != nil {
 			return err
 		}
@@ -244,7 +248,10 @@ func runCreateUser(cmd *cobra.Command, args []string) error {
 		if config.Username == "" {
 			return fmt.Errorf("config file must define a username")
 		}
-		accessToken, err := config.AccessTokenRef.ResolveAccessToken(config.AccessToken)
+		accessToken, err := accesstoken.Resolve(accesstoken.Input{
+			Inline: config.AccessToken,
+			Ref:    config.AccessTokenRef,
+		})
 		if err != nil {
 			return err
 		}

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -1,11 +1,10 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
+	"github.com/mcpjungle/mcpjungle/pkg/configfiles"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -296,47 +295,30 @@ func runCreateToolGroup(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// readToolGroupConfig reads the tool group configuration from a JSON file.
 func readToolGroupConfig(filePath string) (*types.ToolGroup, error) {
-	var input types.ToolGroup
-
-	data, err := os.ReadFile(filePath)
+	input, err := configfiles.ReadJSONFile[types.ToolGroup](filePath)
 	if err != nil {
-		return &input, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+		return nil, err
 	}
-	if err := json.Unmarshal(data, &input); err != nil {
-		return &input, fmt.Errorf("failed to parse config file: %w", err)
-	}
-
 	return &input, nil
 }
 
 // readMcpClientConfig reads the MCP client configuration from a JSON file.
 func readMcpClientConfig(filePath string) (*types.McpClientConfig, error) {
-	var input types.McpClientConfig
-
-	data, err := os.ReadFile(filePath)
+	input, err := configfiles.ReadJSONFile[types.McpClientConfig](filePath)
 	if err != nil {
-		return &input, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+		return nil, err
 	}
-	if err := json.Unmarshal(data, &input); err != nil {
-		return &input, fmt.Errorf("failed to parse config file: %w", err)
-	}
-
 	return &input, nil
 }
 
 // readUserConfig reads the user configuration from a JSON file.
 func readUserConfig(filePath string) (*types.UserConfig, error) {
-	var input types.UserConfig
-
-	data, err := os.ReadFile(filePath)
+	input, err := configfiles.ReadJSONFile[types.UserConfig](filePath)
 	if err != nil {
-		return &input, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+		return nil, err
 	}
-	if err := json.Unmarshal(data, &input); err != nil {
-		return &input, fmt.Errorf("failed to parse config file: %w", err)
-	}
-
 	return &input, nil
 }
 

--- a/cmd/create.go
+++ b/cmd/create.go
@@ -181,7 +181,7 @@ func runCreateMcpClient(cmd *cobra.Command, args []string) error {
 			Description: config.Description,
 			AllowList:   config.AllowMcpServers,
 		}
-		accessToken, err := resolveAccessTokenFromConfig(config.AccessToken, config.AccessTokenRef)
+		accessToken, err := config.AccessTokenRef.ResolveAccessToken(config.AccessToken)
 		if err != nil {
 			return err
 		}
@@ -245,7 +245,7 @@ func runCreateUser(cmd *cobra.Command, args []string) error {
 		if config.Username == "" {
 			return fmt.Errorf("config file must define a username")
 		}
-		accessToken, err := resolveAccessTokenFromConfig(config.AccessToken, config.AccessTokenRef)
+		accessToken, err := config.AccessTokenRef.ResolveAccessToken(config.AccessToken)
 		if err != nil {
 			return err
 		}
@@ -354,45 +354,6 @@ func parseAllowList(input string, cmd *cobra.Command) []string {
 	}
 
 	return allowList
-}
-
-// resolveAccessTokenFromConfig resolves the access token from the provided config.
-// Precedence:
-// 1. Direct access token string
-// 2. Environment variable specified in accessTokenRef.Env
-// 3. File specified in accessTokenRef.File
-// If none are provided, returns an empty string.
-func resolveAccessTokenFromConfig(accessToken string, accessTokenRef types.AccessTokenRef) (string, error) {
-	if accessToken != "" {
-		return accessToken, nil
-	}
-
-	if accessTokenRef.Env != "" {
-		value, ok := os.LookupEnv(accessTokenRef.Env)
-		if ok {
-			trimmed := strings.TrimSpace(value)
-			if trimmed != "" {
-				return trimmed, nil
-			}
-		}
-		if accessTokenRef.File == "" {
-			return "", fmt.Errorf("environment variable %s is not set or empty", accessTokenRef.Env)
-		}
-	}
-
-	if accessTokenRef.File != "" {
-		data, err := os.ReadFile(accessTokenRef.File)
-		if err != nil {
-			return "", fmt.Errorf("failed to read access token file %s: %w", accessTokenRef.File, err)
-		}
-		trimmed := strings.TrimSpace(string(data))
-		if trimmed == "" {
-			return "", fmt.Errorf("access token file %s is empty", accessTokenRef.File)
-		}
-		return trimmed, nil
-	}
-
-	return "", nil
 }
 
 // warnAllowAll displays a warning message about using a wildcard in the allow list.

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -214,7 +214,8 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 
 	t.Run("direct token wins", func(t *testing.T) {
 		t.Parallel()
-		token, err := resolveAccessTokenFromConfig("direct-token", types.AccessTokenRef{})
+		r := types.AccessTokenRef{}
+		token, err := r.ResolveAccessToken("direct-token")
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "direct-token", token)
 	})
@@ -225,7 +226,8 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		_ = os.Setenv(env, "  env-token  ")
 		defer os.Unsetenv(env)
 
-		token, err := resolveAccessTokenFromConfig("", types.AccessTokenRef{Env: env})
+		r := types.AccessTokenRef{Env: env}
+		token, err := r.ResolveAccessToken("")
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "env-token", token)
 	})
@@ -236,7 +238,8 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		_ = os.Setenv(env, "   ")
 		defer os.Unsetenv(env)
 
-		_, err := resolveAccessTokenFromConfig("", types.AccessTokenRef{Env: env})
+		r := types.AccessTokenRef{Env: env}
+		_, err := r.ResolveAccessToken("")
 		testhelpers.AssertError(t, err)
 	})
 
@@ -247,7 +250,8 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		_ = os.WriteFile(f.Name(), []byte("  file-token\n"), 0o600)
 		defer os.Remove(f.Name())
 
-		token, err := resolveAccessTokenFromConfig("", types.AccessTokenRef{File: f.Name()})
+		r := types.AccessTokenRef{File: f.Name()}
+		token, err := r.ResolveAccessToken("")
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "file-token", token)
 	})
@@ -263,14 +267,16 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		_ = os.WriteFile(f.Name(), []byte("from-file"), 0o600)
 		defer os.Remove(f.Name())
 
-		token, err := resolveAccessTokenFromConfig("", types.AccessTokenRef{Env: env, File: f.Name()})
+		r := types.AccessTokenRef{Env: env, File: f.Name()}
+		token, err := r.ResolveAccessToken("")
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "from-file", token)
 	})
 
 	t.Run("missing file -> error", func(t *testing.T) {
 		t.Parallel()
-		_, err := resolveAccessTokenFromConfig("", types.AccessTokenRef{File: "/no/such/file/xxxx"})
+		r := types.AccessTokenRef{File: "/no/such/file/xxxx"}
+		_, err := r.ResolveAccessToken("")
 		testhelpers.AssertError(t, err)
 	})
 
@@ -281,13 +287,15 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		// leave file empty
 		defer os.Remove(f.Name())
 
-		_, err = resolveAccessTokenFromConfig("", types.AccessTokenRef{File: f.Name()})
+		r := types.AccessTokenRef{File: f.Name()}
+		_, err = r.ResolveAccessToken("")
 		testhelpers.AssertError(t, err)
 	})
 
 	t.Run("nothing provided -> empty and no error", func(t *testing.T) {
 		t.Parallel()
-		token, err := resolveAccessTokenFromConfig("", types.AccessTokenRef{})
+		r := types.AccessTokenRef{}
+		token, err := r.ResolveAccessToken("")
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "", token)
 	})

--- a/cmd/create_test.go
+++ b/cmd/create_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/mcpjungle/mcpjungle/pkg/accesstoken"
 	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"github.com/spf13/cobra"
@@ -215,7 +216,7 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 	t.Run("direct token wins", func(t *testing.T) {
 		t.Parallel()
 		r := types.AccessTokenRef{}
-		token, err := r.ResolveAccessToken("direct-token")
+		token, err := accesstoken.Resolve(accesstoken.Input{Inline: "direct-token", Ref: r})
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "direct-token", token)
 	})
@@ -227,7 +228,7 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		defer os.Unsetenv(env)
 
 		r := types.AccessTokenRef{Env: env}
-		token, err := r.ResolveAccessToken("")
+		token, err := accesstoken.Resolve(accesstoken.Input{Ref: r})
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "env-token", token)
 	})
@@ -239,7 +240,7 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		defer os.Unsetenv(env)
 
 		r := types.AccessTokenRef{Env: env}
-		_, err := r.ResolveAccessToken("")
+		_, err := accesstoken.Resolve(accesstoken.Input{Ref: r})
 		testhelpers.AssertError(t, err)
 	})
 
@@ -251,7 +252,7 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		defer os.Remove(f.Name())
 
 		r := types.AccessTokenRef{File: f.Name()}
-		token, err := r.ResolveAccessToken("")
+		token, err := accesstoken.Resolve(accesstoken.Input{Ref: r})
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "file-token", token)
 	})
@@ -268,7 +269,7 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		defer os.Remove(f.Name())
 
 		r := types.AccessTokenRef{Env: env, File: f.Name()}
-		token, err := r.ResolveAccessToken("")
+		token, err := accesstoken.Resolve(accesstoken.Input{Ref: r})
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "from-file", token)
 	})
@@ -276,7 +277,7 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 	t.Run("missing file -> error", func(t *testing.T) {
 		t.Parallel()
 		r := types.AccessTokenRef{File: "/no/such/file/xxxx"}
-		_, err := r.ResolveAccessToken("")
+		_, err := accesstoken.Resolve(accesstoken.Input{Ref: r})
 		testhelpers.AssertError(t, err)
 	})
 
@@ -288,14 +289,14 @@ func TestResolveAccessTokenFromConfig(t *testing.T) {
 		defer os.Remove(f.Name())
 
 		r := types.AccessTokenRef{File: f.Name()}
-		_, err = r.ResolveAccessToken("")
+		_, err = accesstoken.Resolve(accesstoken.Input{Ref: r})
 		testhelpers.AssertError(t, err)
 	})
 
 	t.Run("nothing provided -> empty and no error", func(t *testing.T) {
 		t.Parallel()
 		r := types.AccessTokenRef{}
-		token, err := r.ResolveAccessToken("")
+		token, err := accesstoken.Resolve(accesstoken.Input{Ref: r})
 		testhelpers.AssertNoError(t, err)
 		testhelpers.AssertEqual(t, "", token)
 	})

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -1,10 +1,9 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 
+	"github.com/mcpjungle/mcpjungle/pkg/configfiles"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"github.com/spf13/cobra"
 )
@@ -87,18 +86,7 @@ func init() {
 }
 
 func readMcpServerConfig(filePath string) (types.RegisterServerInput, error) {
-	var input types.RegisterServerInput
-
-	data, err := os.ReadFile(filePath)
-	if err != nil {
-		return input, fmt.Errorf("failed to read config file %s: %w", filePath, err)
-	}
-	// Parse JSON config
-	if err := json.Unmarshal(data, &input); err != nil {
-		return input, fmt.Errorf("failed to parse config file: %w", err)
-	}
-
-	return input, nil
+	return configfiles.ReadJSONFile[types.RegisterServerInput](filePath)
 }
 
 func runRegisterMCPServer(cmd *cobra.Command, args []string) error {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -29,17 +29,18 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
 	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/mcpjungle/mcpjungle/internal/telemetry"
+	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"github.com/spf13/cobra"
 )
 
 const (
-	BindPortEnvVar           = "PORT"
-	BindPortDefault          = "8080"
-	DefaultConfigSyncDirName = ".mcpjungle"
+	BindPortEnvVar  = "PORT"
+	BindPortDefault = "8080"
 
-	DBUrlEnvVar             = "DATABASE_URL"
-	ServerModeEnvVar        = "SERVER_MODE"
-	TelemetryEnabledEnvVar  = "OTEL_ENABLED"
+	DBUrlEnvVar            = "DATABASE_URL"
+	ServerModeEnvVar       = "SERVER_MODE"
+	TelemetryEnabledEnvVar = "OTEL_ENABLED"
+
 	ConfigSyncEnabledEnvVar = "MCPJUNGLE_CONFIG_SYNC_ENABLED"
 	ConfigSyncDirEnvVar     = "MCPJUNGLE_CONFIG_DIR"
 )
@@ -346,9 +347,9 @@ func getConfigSyncDir() string {
 	}
 	homeDir, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join("~", DefaultConfigSyncDirName)
+		return filepath.Join("~", types.DefaultConfigSyncDirName)
 	}
-	return filepath.Join(homeDir, DefaultConfigSyncDirName)
+	return filepath.Join(homeDir, types.DefaultConfigSyncDirName)
 }
 
 func runStartServer(cmd *cobra.Command, args []string) error {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -322,6 +322,8 @@ func getSessionIdleTimeout() (int, error) {
 	return timeout, nil
 }
 
+// getConfigSyncEnabled returns true if config directory sync is enabled via the flag or environment variable,
+// false otherwise.
 func getConfigSyncEnabled() bool {
 	if startServerCmdConfigSyncEnabled {
 		return true
@@ -330,6 +332,10 @@ func getConfigSyncEnabled() bool {
 	return v == "1" || v == "true"
 }
 
+// getConfigSyncDir returns the directory to be used for config sync, based on the following precedence:
+// 1. Command line flag
+// 2. Environment variable
+// 3. Default value (~/.mcpjungle)
 func getConfigSyncDir() string {
 	if strings.TrimSpace(startServerCmdConfigDir) != "" {
 		return strings.TrimSpace(startServerCmdConfigDir)

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -481,9 +482,11 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create Tool Group service: %v", err)
 	}
 
+	// setup configuration syncing
 	csOpts := configsync.Options{
-		Enabled: getConfigSyncEnabled(),
-		Dir:     getConfigSyncDir(),
+		Enabled:                    getConfigSyncEnabled(),
+		Dir:                        getConfigSyncDir(),
+		EnableEnterpriseEntitySync: model.IsEnterpriseMode(desiredServerMode),
 	}
 	csServices := configsync.Services{
 		MCPService:       mcpService,
@@ -495,8 +498,16 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to initialize config sync service: %w", err)
 	}
 
-	if err := configSyncService.Start(cmd.Context()); err != nil {
-		return fmt.Errorf("failed to start config sync service: %w", err)
+	// config sync should only start after mcpjungle server is initialized
+	// this callback is therefore intended to be called post initialization,
+	// and also on startup if the server is already initialized.
+	var configSyncStartOnce sync.Once
+	startConfigSyncWhenReady := func(reason string) {
+		configSyncStartOnce.Do(func() {
+			if err := configSyncService.Start(cmd.Context()); err != nil {
+				log.Printf("[config-sync] failed to start configuration sync (%s): %v", reason, err)
+			}
+		})
 	}
 	defer configSyncService.Stop()
 
@@ -511,6 +522,10 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		ToolGroupService:  toolGroupService,
 		OtelProviders:     otelProviders,
 		Metrics:           mcpMetrics,
+
+		OnInitialized: func(mode model.ServerMode) {
+			startConfigSyncWhenReady("initialize mcpjungle server")
+		},
 	}
 	s, err := api.NewServer(opts)
 	if err != nil {
@@ -535,6 +550,9 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 				mode, desiredServerMode,
 			)
 		}
+
+		// since mcpjungle is already initialized, we can start config sync already
+		startConfigSyncWhenReady("mcpjungle server startup")
 	} else {
 		// If server isn't already initialized and the desired mode is dev, silently initialize the server.
 		// Individual (dev mode) users need not worry about server initialization.
@@ -542,6 +560,9 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 			if err := s.InitDev(); err != nil {
 				return fmt.Errorf("failed to initialize server in development mode: %v", err)
 			}
+
+			// since the server is now initialized, we can start config sync
+			startConfigSyncWhenReady("auto-initialize mcpjungle server")
 		} else {
 			// If desired mode is enterprise, then server initialization is a manual next step to be taken by the user.
 			// This is so that they can obtain the admin access token on their client machine.
@@ -549,6 +570,9 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 				"Starting server in Enterprise mode," +
 					" don't forget to initialize it by running the `init-server` command",
 			)
+			if csOpts.Enabled {
+				cmd.Println("Configuration syncing is enabled, but it will only work after server initialization.")
+			}
 		}
 	}
 

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -481,17 +481,20 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create Tool Group service: %v", err)
 	}
 
-	configSyncService, err := configsync.New(configsync.Options{
+	csOpts := configsync.Options{
 		Enabled: getConfigSyncEnabled(),
 		Dir:     getConfigSyncDir(),
-	}, configsync.Services{
-		DB:               dbConn,
+	}
+	csServices := configsync.Services{
 		MCPService:       mcpService,
 		ToolGroupService: toolGroupService,
-	})
+		MCPClientService: mcpClientService,
+	}
+	configSyncService, err := configsync.New(csOpts, dbConn, csServices)
 	if err != nil {
 		return fmt.Errorf("failed to initialize config sync service: %w", err)
 	}
+
 	if err := configSyncService.Start(cmd.Context()); err != nil {
 		return fmt.Errorf("failed to start config sync service: %w", err)
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -492,6 +492,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		MCPService:       mcpService,
 		ToolGroupService: toolGroupService,
 		MCPClientService: mcpClientService,
+		UserService:      userService,
 	}
 	configSyncService, err := configsync.New(csOpts, dbConn, csServices)
 	if err != nil {
@@ -524,7 +525,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		Metrics:           mcpMetrics,
 
 		OnInitialized: func(mode model.ServerMode) {
-			startConfigSyncWhenReady("initialize mcpjungle server")
+			startConfigSyncWhenReady(fmt.Sprintf("initialize mcpjungle server in %s mode", mode))
 		},
 	}
 	s, err := api.NewServer(opts)
@@ -566,12 +567,12 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		} else {
 			// If desired mode is enterprise, then server initialization is a manual next step to be taken by the user.
 			// This is so that they can obtain the admin access token on their client machine.
-			cmd.Println(
-				"Starting server in Enterprise mode," +
+			log.Println(
+				"[server] starting server in Enterprise mode," +
 					" don't forget to initialize it by running the `init-server` command",
 			)
 			if csOpts.Enabled {
-				cmd.Println("Configuration syncing is enabled, but it will only work after server initialization.")
+				log.Println("[server] configuration syncing is enabled, but it will only work after server initialization.")
 			}
 		}
 	}

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/mcpjungle/mcpjungle/pkg/types"
 )
 
 func TestStartCommandStructure(t *testing.T) {
@@ -360,7 +362,7 @@ func TestGetConfigSyncDir(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to get user home dir: %v", err)
 			}
-			expected := filepath.Join(home, DefaultConfigSyncDirName)
+			expected := filepath.Join(home, types.DefaultConfigSyncDirName)
 			if got := getConfigSyncDir(); got != expected {
 				t.Fatalf("expected default dir %s, got %s", expected, got)
 			}

--- a/go.mod
+++ b/go.mod
@@ -36,6 +36,7 @@ require (
 	github.com/cloudwego/base64x v0.1.6 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
 	github.com/gin-contrib/sse v1.1.0 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,6 +22,8 @@ github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkp
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/gabriel-vasile/mimetype v1.4.10 h1:zyueNbySn/z8mJZHLt6IPw0KoZsiQNszIpU+bX4+ZK0=
 github.com/gabriel-vasile/mimetype v1.4.10/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
 github.com/gin-contrib/sse v1.1.0 h1:n0w2GMuUpWDVp7qSpvze6fAu9iRxJY4Hmj6AmBOU05w=

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -45,6 +45,9 @@ type ServerOptions struct {
 
 	OtelProviders *telemetry.Providers
 	Metrics       telemetry.CustomMetrics
+
+	// OnInitialized is an optional callback that gets called when the server is initialized
+	OnInitialized func(mode model.ServerMode)
 }
 
 // Server represents the MCPJungle registry server that handles MCP proxy and API requests
@@ -63,6 +66,7 @@ type Server struct {
 
 	otelProviders *telemetry.Providers
 	metrics       telemetry.CustomMetrics
+	onInitialized func(mode model.ServerMode)
 
 	// groupMcpServers keeps track of mcp-go's server.SSEServer instances created for each tool group.
 	// These instances serve the requests made to tool groups' SSE tools.
@@ -82,6 +86,7 @@ func NewServer(opts *ServerOptions) (*Server, error) {
 		toolGroupService:  opts.ToolGroupService,
 		otelProviders:     opts.OtelProviders,
 		metrics:           opts.Metrics,
+		onInitialized:     opts.OnInitialized,
 	}
 
 	// Set up the router after the server is fully initialized

--- a/internal/api/server_config.go
+++ b/internal/api/server_config.go
@@ -28,6 +28,9 @@ func (s *Server) registerInitServerHandler() gin.HandlerFunc {
 		if req.Mode == model.ModeDev {
 			// If the server was successfully initialized and the mode is dev,
 			// return a success message without creating an admin user
+			if s.onInitialized != nil {
+				s.onInitialized(req.Mode)
+			}
 			c.JSON(http.StatusOK, gin.H{"status": "Server initialized successfully in development mode"})
 			return
 		}
@@ -40,6 +43,9 @@ func (s *Server) registerInitServerHandler() gin.HandlerFunc {
 				gin.H{"error": "Initialization succeeded but failed to create admin user: " + err.Error()},
 			)
 			return
+		}
+		if s.onInitialized != nil {
+			s.onInitialized(req.Mode)
 		}
 		payload := gin.H{
 			"status":             "Server initialized successfully",

--- a/internal/migrations/migration.go
+++ b/internal/migrations/migration.go
@@ -31,5 +31,8 @@ func Migrate(db *gorm.DB) error {
 	if err := db.AutoMigrate(&model.Prompt{}); err != nil {
 		return fmt.Errorf("auto‑migration failed for Prompt model: %v", err)
 	}
+	if err := db.AutoMigrate(&model.ManagedConfigFile{}); err != nil {
+		return fmt.Errorf("auto‑migration failed for ManagedConfigFile model: %v", err)
+	}
 	return nil
 }

--- a/internal/model/managed_config_file.go
+++ b/internal/model/managed_config_file.go
@@ -2,14 +2,23 @@ package model
 
 import "gorm.io/gorm"
 
+// EntityType is the type of entity, e.g., mcp_server, user, mcp_client, group, etc.
+type EntityType string
+
+const (
+	EntityTypeMcpServer EntityType = "mcp_server"
+	EntityTypeMcpClient EntityType = "mcp_client"
+	EntityTypeUser      EntityType = "user"
+	EntityTypeGroup     EntityType = "group"
+)
+
 // ManagedConfigFile tracks configuration files that represent entities in mcpjungle.
 // Only the files inside the auto-synced config directory are tracked.
 type ManagedConfigFile struct {
 	gorm.Model
 
-	// EntityType is the type of entity, e.g., mcp_server, user, mcp_client, group, etc.
-	EntityType string `json:"entity_type" gorm:"type:varchar(32);not null;index:idx_managed_config_entity,unique"`
-	EntityName string `json:"entity_name" gorm:"type:varchar(255);not null;index:idx_managed_config_entity,unique"`
-	FilePath   string `json:"file_path" gorm:"type:text;not null;index:idx_managed_config_file,unique"`
-	FileHash   string `json:"file_hash" gorm:"type:varchar(128);not null"`
+	EntityType EntityType `json:"entity_type" gorm:"type:varchar(32);not null;index:idx_managed_config_entity,unique"`
+	EntityName string     `json:"entity_name" gorm:"type:varchar(255);not null;index:idx_managed_config_entity,unique"`
+	FilePath   string     `json:"file_path" gorm:"type:text;not null;index:idx_managed_config_file,unique"`
+	FileHash   string     `json:"file_hash" gorm:"type:varchar(128);not null"`
 }

--- a/internal/model/managed_config_file.go
+++ b/internal/model/managed_config_file.go
@@ -1,0 +1,13 @@
+package model
+
+import "gorm.io/gorm"
+
+// ManagedConfigFile tracks entities that are managed through the auto-synced config directory.
+type ManagedConfigFile struct {
+	gorm.Model
+
+	EntityType string `json:"entity_type" gorm:"type:varchar(32);not null;index:idx_managed_config_entity,unique"`
+	EntityName string `json:"entity_name" gorm:"type:varchar(255);not null;index:idx_managed_config_entity,unique"`
+	FilePath   string `json:"file_path" gorm:"type:text;not null;index:idx_managed_config_file,unique"`
+	FileHash   string `json:"file_hash" gorm:"type:varchar(128);not null"`
+}

--- a/internal/model/managed_config_file.go
+++ b/internal/model/managed_config_file.go
@@ -2,10 +2,12 @@ package model
 
 import "gorm.io/gorm"
 
-// ManagedConfigFile tracks entities that are managed through the auto-synced config directory.
+// ManagedConfigFile tracks configuration files that represent entities in mcpjungle.
+// Only the files inside the auto-synced config directory are tracked.
 type ManagedConfigFile struct {
 	gorm.Model
 
+	// EntityType is the type of entity, e.g., mcp_server, user, mcp_client, group, etc.
 	EntityType string `json:"entity_type" gorm:"type:varchar(32);not null;index:idx_managed_config_entity,unique"`
 	EntityName string `json:"entity_name" gorm:"type:varchar(255);not null;index:idx_managed_config_entity,unique"`
 	FilePath   string `json:"file_path" gorm:"type:text;not null;index:idx_managed_config_file,unique"`

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -1,0 +1,689 @@
+package configsync
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
+	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
+	"github.com/mcpjungle/mcpjungle/pkg/types"
+	"gorm.io/datatypes"
+	"gorm.io/gorm"
+)
+
+const (
+	entityMcpServer = "mcp_server"
+	entityMcpClient = "mcp_client"
+	entityGroup     = "group"
+	entityUser      = "user"
+)
+
+// Options configures config directory synchronization.
+type Options struct {
+	Enabled bool
+	Dir     string
+}
+
+type Services struct {
+	DB               *gorm.DB
+	MCPService       *mcp.MCPService
+	ToolGroupService *toolgroup.ToolGroupService
+}
+
+type Service struct {
+	opts     Options
+	services Services
+
+	resolvedDir string
+
+	watcher *fsnotify.Watcher
+	cancel  context.CancelFunc
+	wg      sync.WaitGroup
+}
+
+func New(opts Options, services Services) (*Service, error) {
+	if services.DB == nil || services.MCPService == nil || services.ToolGroupService == nil {
+		return nil, fmt.Errorf("config sync requires DB, MCP service and ToolGroup service")
+	}
+	if !opts.Enabled {
+		return &Service{opts: opts, services: services}, nil
+	}
+	resolved, err := resolveConfigDir(opts.Dir)
+	if err != nil {
+		return nil, err
+	}
+	return &Service{opts: opts, services: services, resolvedDir: resolved}, nil
+}
+
+func resolveConfigDir(dir string) (string, error) {
+	target := strings.TrimSpace(dir)
+	if target == "" {
+		target = "~/.mcpjungle"
+	}
+	if strings.HasPrefix(target, "~") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if target == "~" {
+			target = home
+		} else if strings.HasPrefix(target, "~/") {
+			target = filepath.Join(home, target[2:])
+		}
+	}
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(abs), nil
+}
+
+func (s *Service) Start(ctx context.Context) error {
+	if !s.opts.Enabled {
+		return nil
+	}
+	if err := ensureSubDirs(s.resolvedDir); err != nil {
+		return err
+	}
+	if err := s.Reconcile(ctx); err != nil {
+		return fmt.Errorf("initial config reconciliation failed: %w", err)
+	}
+
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return fmt.Errorf("failed to create file watcher: %w", err)
+	}
+	s.watcher = watcher
+	for _, d := range []string{
+		s.resolvedDir,
+		filepath.Join(s.resolvedDir, "mcp_servers"),
+		filepath.Join(s.resolvedDir, "mcp_clients"),
+		filepath.Join(s.resolvedDir, "groups"),
+		filepath.Join(s.resolvedDir, "users"),
+	} {
+		if err := watcher.Add(d); err != nil {
+			_ = watcher.Close()
+			return fmt.Errorf("failed to watch %s: %w", d, err)
+		}
+	}
+
+	watchCtx, cancel := context.WithCancel(ctx)
+	s.cancel = cancel
+	s.wg.Add(1)
+	go s.watchLoop(watchCtx)
+	return nil
+}
+
+func (s *Service) Stop() {
+	if s.cancel != nil {
+		s.cancel()
+	}
+	s.wg.Wait()
+	if s.watcher != nil {
+		_ = s.watcher.Close()
+	}
+}
+
+func (s *Service) watchLoop(ctx context.Context) {
+	defer s.wg.Done()
+	debounce := time.NewTimer(time.Hour)
+	if !debounce.Stop() {
+		<-debounce.C
+	}
+	pending := false
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case err, ok := <-s.watcher.Errors:
+			if !ok {
+				return
+			}
+			log.Printf("[config-sync] watcher error: %v", err)
+		case ev, ok := <-s.watcher.Events:
+			if !ok {
+				return
+			}
+			if !isRelevantEvent(ev) {
+				continue
+			}
+			pending = true
+			debounce.Reset(300 * time.Millisecond)
+		case <-debounce.C:
+			if pending {
+				if err := s.Reconcile(context.Background()); err != nil {
+					log.Printf("[config-sync] reconcile failed after file changes: %v", err)
+				}
+				pending = false
+			}
+		}
+	}
+}
+
+func isRelevantEvent(ev fsnotify.Event) bool {
+	return ev.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove|fsnotify.Rename) != 0
+}
+
+func ensureSubDirs(root string) error {
+	for _, sub := range []string{"mcp_servers", "mcp_clients", "groups", "users"} {
+		if err := os.MkdirAll(filepath.Join(root, sub), 0o755); err != nil {
+			return fmt.Errorf("failed to create config subdirectory %s: %w", sub, err)
+		}
+	}
+	return nil
+}
+
+func (s *Service) Reconcile(ctx context.Context) error {
+	var errs []error
+	if err := s.reconcileMcpServers(ctx); err != nil {
+		errs = append(errs, err)
+	}
+	if err := s.reconcileMcpClients(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := s.reconcileGroups(); err != nil {
+		errs = append(errs, err)
+	}
+	if err := s.reconcileUsers(); err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		for _, err := range errs {
+			log.Printf("[config-sync] %v", err)
+		}
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+type desiredFile[T any] struct {
+	entity   T
+	name     string
+	path     string
+	hash     string
+	parseErr error
+}
+
+func loadDesired[T any](dir string, nameFn func(T) string) (map[string]desiredFile[T], map[string]bool, []error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, []error{fmt.Errorf("failed to read directory %s: %w", dir, err)}
+	}
+	result := map[string]desiredFile[T]{}
+	blocked := map[string]bool{}
+	var errs []error
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		full := filepath.Join(dir, e.Name())
+		raw, err := os.ReadFile(full)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to read config file %s: %w", full, err))
+			blocked[full] = true
+			continue
+		}
+		var conf T
+		if err := json.Unmarshal(raw, &conf); err != nil {
+			errs = append(errs, fmt.Errorf("invalid JSON in %s: %w", full, err))
+			blocked[full] = true
+			continue
+		}
+		name := strings.TrimSpace(nameFn(conf))
+		if name == "" {
+			errs = append(errs, fmt.Errorf("config file %s does not define a valid name", full))
+			blocked[full] = true
+			continue
+		}
+		if existing, ok := result[name]; ok {
+			errs = append(errs, fmt.Errorf("conflict: duplicate %s defined by %s and %s", name, existing.path, full))
+			blocked[full] = true
+			blocked[existing.path] = true
+			continue
+		}
+		h := sha256.Sum256(raw)
+		result[name] = desiredFile[T]{
+			entity: conf,
+			name:   name,
+			path:   full,
+			hash:   hex.EncodeToString(h[:]),
+		}
+	}
+	return result, blocked, errs
+}
+
+func (s *Service) loadManaged(entityType string) (map[string]model.ManagedConfigFile, error) {
+	var rows []model.ManagedConfigFile
+	if err := s.services.DB.Where("entity_type = ?", entityType).Find(&rows).Error; err != nil {
+		return nil, err
+	}
+	out := make(map[string]model.ManagedConfigFile, len(rows))
+	for _, r := range rows {
+		out[r.EntityName] = r
+	}
+	return out, nil
+}
+
+func toJSON(v any) (datatypes.JSON, error) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	return datatypes.JSON(b), nil
+}
+
+func (s *Service) createOrUpdateManagedRow(entityType, name, path, hash string) error {
+	var row model.ManagedConfigFile
+	err := s.services.DB.Where("entity_type = ? AND entity_name = ?", entityType, name).First(&row).Error
+	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		return err
+	}
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return s.services.DB.Create(&model.ManagedConfigFile{
+			EntityType: entityType,
+			EntityName: name,
+			FilePath:   path,
+			FileHash:   hash,
+		}).Error
+	}
+	row.FilePath = path
+	row.FileHash = hash
+	return s.services.DB.Save(&row).Error
+}
+
+func (s *Service) deleteManagedRow(entityType, name string) error {
+	return s.services.DB.Unscoped().Where("entity_type = ? AND entity_name = ?", entityType, name).Delete(&model.ManagedConfigFile{}).Error
+}
+
+func (s *Service) reconcileMcpServers(ctx context.Context) error {
+	desired, blocked, parseErrs := loadDesired[types.RegisterServerInput](filepath.Join(s.resolvedDir, "mcp_servers"), func(i types.RegisterServerInput) string { return i.Name })
+	managed, err := s.loadManaged(entityMcpServer)
+	if err != nil {
+		return fmt.Errorf("failed to load tracked mcp server configs: %w", err)
+	}
+	var errs []error
+	errs = append(errs, parseErrs...)
+
+	for name, d := range desired {
+		transport, err := types.ValidateTransport(d.entity.Transport)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid transport in %s: %w", d.path, err))
+			continue
+		}
+		sessionMode, err := types.ValidateSessionMode(d.entity.SessionMode)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid session_mode in %s: %w", d.path, err))
+			continue
+		}
+		server, err := newServerFromInput(d.entity, transport, sessionMode)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid mcp server config in %s: %w", d.path, err))
+			continue
+		}
+
+		existing, getErr := s.services.MCPService.GetMcpServer(name)
+		if getErr != nil && !errors.Is(getErr, gorm.ErrRecordNotFound) {
+			errs = append(errs, fmt.Errorf("failed to read mcp server %s: %w", name, getErr))
+			continue
+		}
+
+		track, tracked := managed[name]
+		if errors.Is(getErr, gorm.ErrRecordNotFound) {
+			if err := s.services.MCPService.RegisterMcpServer(ctx, server); err != nil {
+				errs = append(errs, fmt.Errorf("failed to create mcp server %s from %s: %w", name, d.path, err))
+				continue
+			}
+			if err := s.createOrUpdateManagedRow(entityMcpServer, name, d.path, d.hash); err != nil {
+				errs = append(errs, fmt.Errorf("failed to track mcp server %s: %w", name, err))
+			}
+			continue
+		}
+
+		if !tracked {
+			// adopt existing manually managed entity
+			tracked = true
+			track = model.ManagedConfigFile{EntityName: name}
+		}
+
+		if tracked && track.FileHash == d.hash {
+			continue
+		}
+
+		if !serverEqual(existing, server) {
+			if err := s.services.MCPService.DeregisterMcpServer(name); err != nil {
+				errs = append(errs, fmt.Errorf("failed to deregister mcp server %s for update: %w", name, err))
+				continue
+			}
+			if err := s.services.MCPService.RegisterMcpServer(ctx, server); err != nil {
+				errs = append(errs, fmt.Errorf("failed to register updated mcp server %s from %s: %w", name, d.path, err))
+				continue
+			}
+		}
+		if err := s.createOrUpdateManagedRow(entityMcpServer, name, d.path, d.hash); err != nil {
+			errs = append(errs, fmt.Errorf("failed to track mcp server %s: %w", name, err))
+		}
+	}
+
+	for name, trackedRow := range managed {
+		if _, ok := desired[name]; ok {
+			continue
+		}
+		if blocked[trackedRow.FilePath] || fileExists(trackedRow.FilePath) {
+			continue
+		}
+		if err := s.services.MCPService.DeregisterMcpServer(name); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete managed mcp server %s after file removal: %w", name, err))
+			continue
+		}
+		if err := s.deleteManagedRow(entityMcpServer, name); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove tracking for mcp server %s: %w", name, err))
+		}
+	}
+
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func newServerFromInput(input types.RegisterServerInput, transport types.McpServerTransport, sessionMode types.SessionMode) (*model.McpServer, error) {
+	switch transport {
+	case types.TransportStreamableHTTP:
+		return model.NewStreamableHTTPServer(input.Name, input.Description, input.URL, input.BearerToken, input.Headers, sessionMode)
+	case types.TransportStdio:
+		return model.NewStdioServer(input.Name, input.Description, input.Command, input.Args, input.Env, sessionMode)
+	default:
+		return model.NewSSEServer(input.Name, input.Description, input.URL, input.BearerToken, sessionMode)
+	}
+}
+
+func serverEqual(a, b *model.McpServer) bool {
+	return a.Name == b.Name && a.Description == b.Description && a.Transport == b.Transport && a.SessionMode == b.SessionMode && slices.Equal(a.Config, b.Config)
+}
+
+func (s *Service) reconcileMcpClients() error {
+	desired, blocked, parseErrs := loadDesired[types.McpClientConfig](filepath.Join(s.resolvedDir, "mcp_clients"), func(i types.McpClientConfig) string { return i.Name })
+	managed, err := s.loadManaged(entityMcpClient)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	errs = append(errs, parseErrs...)
+
+	for name, d := range desired {
+		allowJSON, err := toJSON(d.entity.AllowMcpServers)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid allow list in %s: %w", d.path, err))
+			continue
+		}
+		accessToken, err := resolveAccessTokenFromConfig(d.entity.AccessToken, d.entity.AccessTokenRef)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.path, err))
+			continue
+		}
+		if accessToken == "" {
+			errs = append(errs, fmt.Errorf("mcp client config %s must provide access token or access_token_ref", d.path))
+			continue
+		}
+
+		var existing model.McpClient
+		err = s.services.DB.Where("name = ?", name).First(&existing).Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			errs = append(errs, fmt.Errorf("failed to fetch mcp client %s: %w", name, err))
+			continue
+		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if err := s.services.DB.Create(&model.McpClient{
+				Name:        name,
+				Description: d.entity.Description,
+				AccessToken: accessToken,
+				AllowList:   allowJSON,
+			}).Error; err != nil {
+				errs = append(errs, fmt.Errorf("failed to create mcp client %s: %w", name, err))
+				continue
+			}
+		} else {
+			if existing.Description != d.entity.Description || existing.AccessToken != accessToken || !slices.Equal(existing.AllowList, allowJSON) {
+				existing.Description = d.entity.Description
+				existing.AccessToken = accessToken
+				existing.AllowList = allowJSON
+				if err := s.services.DB.Save(&existing).Error; err != nil {
+					errs = append(errs, fmt.Errorf("failed to update mcp client %s: %w", name, err))
+					continue
+				}
+			}
+		}
+		if err := s.createOrUpdateManagedRow(entityMcpClient, name, d.path, d.hash); err != nil {
+			errs = append(errs, fmt.Errorf("failed to track mcp client %s: %w", name, err))
+		}
+	}
+
+	for name, trackedRow := range managed {
+		if _, ok := desired[name]; ok {
+			continue
+		}
+		if blocked[trackedRow.FilePath] || fileExists(trackedRow.FilePath) {
+			continue
+		}
+		if err := s.services.DB.Unscoped().Where("name = ?", name).Delete(&model.McpClient{}).Error; err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete managed mcp client %s after file removal: %w", name, err))
+			continue
+		}
+		if err := s.deleteManagedRow(entityMcpClient, name); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove tracking for mcp client %s: %w", name, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func (s *Service) reconcileGroups() error {
+	desired, blocked, parseErrs := loadDesired[types.ToolGroup](filepath.Join(s.resolvedDir, "groups"), func(i types.ToolGroup) string { return i.Name })
+	managed, err := s.loadManaged(entityGroup)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	errs = append(errs, parseErrs...)
+
+	for name, d := range desired {
+		incTools, err := toJSON(d.entity.IncludedTools)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid included_tools in %s: %w", d.path, err))
+			continue
+		}
+		incServers, err := toJSON(d.entity.IncludedServers)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid included_servers in %s: %w", d.path, err))
+			continue
+		}
+		exclTools, err := toJSON(d.entity.ExcludedTools)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("invalid excluded_tools in %s: %w", d.path, err))
+			continue
+		}
+		groupModel := &model.ToolGroup{Name: name, Description: d.entity.Description, IncludedTools: incTools, IncludedServers: incServers, ExcludedTools: exclTools}
+		_, tracked := managed[name]
+		old, err := s.services.ToolGroupService.GetToolGroup(name)
+		if err != nil {
+			if errors.Is(err, toolgroup.ErrToolGroupNotFound) {
+				if err := s.services.ToolGroupService.CreateToolGroup(groupModel); err != nil {
+					errs = append(errs, fmt.Errorf("failed to create group %s from %s: %w", name, d.path, err))
+					continue
+				}
+			} else {
+				errs = append(errs, fmt.Errorf("failed to fetch group %s: %w", name, err))
+				continue
+			}
+		} else {
+			if !tracked || !groupEqual(old, groupModel) {
+				if _, err := s.services.ToolGroupService.UpdateToolGroup(name, groupModel); err != nil {
+					errs = append(errs, fmt.Errorf("failed to update group %s from %s: %w", name, d.path, err))
+					continue
+				}
+			}
+		}
+		if err := s.createOrUpdateManagedRow(entityGroup, name, d.path, d.hash); err != nil {
+			errs = append(errs, fmt.Errorf("failed to track group %s: %w", name, err))
+		}
+	}
+	for name, trackedRow := range managed {
+		if _, ok := desired[name]; ok {
+			continue
+		}
+		if blocked[trackedRow.FilePath] || fileExists(trackedRow.FilePath) {
+			continue
+		}
+		if err := s.services.ToolGroupService.DeleteToolGroup(name); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete managed group %s after file removal: %w", name, err))
+			continue
+		}
+		if err := s.deleteManagedRow(entityGroup, name); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove tracking for group %s: %w", name, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func groupEqual(a, b *model.ToolGroup) bool {
+	return a.Name == b.Name && a.Description == b.Description && slices.Equal(a.IncludedTools, b.IncludedTools) && slices.Equal(a.IncludedServers, b.IncludedServers) && slices.Equal(a.ExcludedTools, b.ExcludedTools)
+}
+
+func (s *Service) reconcileUsers() error {
+	desired, blocked, parseErrs := loadDesired[types.UserConfig](filepath.Join(s.resolvedDir, "users"), func(i types.UserConfig) string { return i.Username })
+	managed, err := s.loadManaged(entityUser)
+	if err != nil {
+		return err
+	}
+	var errs []error
+	errs = append(errs, parseErrs...)
+
+	for name, d := range desired {
+		accessToken, err := resolveAccessTokenFromConfig(d.entity.AccessToken, d.entity.AccessTokenRef)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.path, err))
+			continue
+		}
+		if accessToken == "" {
+			errs = append(errs, fmt.Errorf("user config %s must provide access token or access_token_ref", d.path))
+			continue
+		}
+
+		var existing model.User
+		err = s.services.DB.Where("username = ?", name).First(&existing).Error
+		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+			errs = append(errs, fmt.Errorf("failed to fetch user %s: %w", name, err))
+			continue
+		}
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			if err := s.services.DB.Create(&model.User{Username: name, Role: types.UserRoleUser, AccessToken: accessToken}).Error; err != nil {
+				errs = append(errs, fmt.Errorf("failed to create user %s: %w", name, err))
+				continue
+			}
+		} else {
+			if existing.Role == types.UserRoleAdmin {
+				errs = append(errs, fmt.Errorf("config sync cannot manage admin user %s (file: %s)", name, d.path))
+				continue
+			}
+			if existing.AccessToken != accessToken {
+				existing.AccessToken = accessToken
+				if err := s.services.DB.Save(&existing).Error; err != nil {
+					errs = append(errs, fmt.Errorf("failed to update user %s: %w", name, err))
+					continue
+				}
+			}
+		}
+
+		if err := s.createOrUpdateManagedRow(entityUser, name, d.path, d.hash); err != nil {
+			errs = append(errs, fmt.Errorf("failed to track user %s: %w", name, err))
+		}
+	}
+	for name, trackedRow := range managed {
+		if _, ok := desired[name]; ok {
+			continue
+		}
+		if blocked[trackedRow.FilePath] || fileExists(trackedRow.FilePath) {
+			continue
+		}
+		var user model.User
+		if err := s.services.DB.Where("username = ?", name).First(&user).Error; err != nil {
+			if errors.Is(err, gorm.ErrRecordNotFound) {
+				_ = s.deleteManagedRow(entityUser, name)
+				continue
+			}
+			errs = append(errs, fmt.Errorf("failed to fetch managed user %s during deletion: %w", name, err))
+			continue
+		}
+		if user.Role == types.UserRoleAdmin {
+			errs = append(errs, fmt.Errorf("config sync cannot delete admin user %s", name))
+			continue
+		}
+		if err := s.services.DB.Unscoped().Where("username = ?", name).Delete(&model.User{}).Error; err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete managed user %s after file removal: %w", name, err))
+			continue
+		}
+		if err := s.deleteManagedRow(entityUser, name); err != nil {
+			errs = append(errs, fmt.Errorf("failed to remove tracking for user %s: %w", name, err))
+		}
+	}
+	if len(errs) > 0 {
+		return errors.Join(errs...)
+	}
+	return nil
+}
+
+func fileExists(path string) bool {
+	if strings.TrimSpace(path) == "" {
+		return false
+	}
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+func resolveAccessTokenFromConfig(accessToken string, ref types.AccessTokenRef) (string, error) {
+	if strings.TrimSpace(accessToken) != "" {
+		return strings.TrimSpace(accessToken), nil
+	}
+	if strings.TrimSpace(ref.Env) != "" {
+		v, ok := os.LookupEnv(ref.Env)
+		if ok {
+			v = strings.TrimSpace(v)
+			if v != "" {
+				return v, nil
+			}
+		}
+		if strings.TrimSpace(ref.File) == "" {
+			return "", fmt.Errorf("environment variable %s is not set or empty", ref.Env)
+		}
+	}
+	if strings.TrimSpace(ref.File) != "" {
+		data, err := os.ReadFile(ref.File)
+		if err != nil {
+			return "", fmt.Errorf("failed to read access token file %s: %w", ref.File, err)
+		}
+		v := strings.TrimSpace(string(data))
+		if v == "" {
+			return "", fmt.Errorf("access token file %s is empty", ref.File)
+		}
+		return v, nil
+	}
+	return "", nil
+}

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -58,13 +58,24 @@ type Service struct {
 }
 
 func New(opts Options, db *gorm.DB, services Services) (*Service, error) {
+	cs := &Service{opts: opts, db: db, services: services}
+
+	if !opts.Enabled {
+		// if syncing is not enabled, we can skip all the validation of dependencies and just return the service
+		// as-is, since it will be a no-op
+		return cs, nil
+	}
+
 	if db == nil || services.MCPService == nil || services.ToolGroupService == nil {
 		return nil, fmt.Errorf("config sync requires DB, MCP service and ToolGroup service")
+	}
+	if opts.EnableEnterpriseEntitySync && (services.UserService == nil || services.MCPClientService == nil) {
+		return nil, fmt.Errorf("config sync with enterprise entity syncing enabled requires User service and MCP Client service")
 	}
 	if opts.Dir == "" {
 		return nil, fmt.Errorf("config sync requires a directory to watch")
 	}
-	return &Service{opts: opts, db: db, services: services}, nil
+	return cs, nil
 }
 
 // Start begins watching the config directory for changes in the background and reconciling them with mcpjungle.

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -18,7 +18,9 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"github.com/mcpjungle/mcpjungle/internal/model"
 	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
 	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
+	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -32,13 +34,15 @@ type Options struct {
 
 // Services groups the external services that the config sync service depends on to do its job.
 type Services struct {
-	DB               *gorm.DB
 	MCPService       *mcp.MCPService
 	ToolGroupService *toolgroup.ToolGroupService
+	UserService      *user.UserService
+	MCPClientService *mcpclient.McpClientService
 }
 
 type Service struct {
 	opts     Options
+	db       *gorm.DB
 	services Services
 
 	watcher *fsnotify.Watcher
@@ -46,14 +50,14 @@ type Service struct {
 	wg      sync.WaitGroup
 }
 
-func New(opts Options, services Services) (*Service, error) {
-	if services.DB == nil || services.MCPService == nil || services.ToolGroupService == nil {
+func New(opts Options, db *gorm.DB, services Services) (*Service, error) {
+	if db == nil || services.MCPService == nil || services.ToolGroupService == nil {
 		return nil, fmt.Errorf("config sync requires DB, MCP service and ToolGroup service")
 	}
 	if opts.Dir == "" {
 		return nil, fmt.Errorf("config sync requires a directory to watch")
 	}
-	return &Service{opts: opts, services: services}, nil
+	return &Service{opts: opts, db: db, services: services}, nil
 }
 
 // Start begins watching the config directory for changes in the background and reconciling them with mcpjungle.
@@ -131,7 +135,7 @@ func (s *Service) watchLoop(ctx context.Context) {
 			if !ok {
 				return
 			}
-			if !isRelevantEvent(ev) {
+			if !isRelevantFsEvent(ev) {
 				continue
 			}
 			pending = true
@@ -147,9 +151,9 @@ func (s *Service) watchLoop(ctx context.Context) {
 	}
 }
 
-// isRelevantEvent filters fsnotify events to only those that are relevant for triggering a reconciliation.
+// isRelevantFsEvent filters fsnotify events to only those that are relevant for triggering a reconciliation.
 // We only care when a file is created, modified, removed, or renamed.
-func isRelevantEvent(ev fsnotify.Event) bool {
+func isRelevantFsEvent(ev fsnotify.Event) bool {
 	return ev.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove|fsnotify.Rename) != 0
 }
 
@@ -193,6 +197,7 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	return nil
 }
 
+// desiredFile represents a config file on disk that we want to be reflected in the system.
 type desiredFile[T any] struct {
 	entity   T
 	name     string
@@ -201,14 +206,21 @@ type desiredFile[T any] struct {
 	parseErr error
 }
 
+// loadDesired reads config files from the specified directory, parses them into entities of type T, and returns
+// a map of entity name to desiredFile.
+// It also returns a map of file paths that had errors during loading (either read errors or parse errors) to
+// a boolean (the value is not used, we just need a set).
+// If there were any errors during loading, it returns a slice of those errors as well.
 func loadDesired[T any](dir string, nameFn func(T) string) (map[string]desiredFile[T], map[string]bool, []error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, nil, []error{fmt.Errorf("failed to read directory %s: %w", dir, err)}
 	}
+
 	result := map[string]desiredFile[T]{}
 	blocked := map[string]bool{}
 	var errs []error
+
 	for _, e := range entries {
 		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
 			continue
@@ -246,12 +258,13 @@ func loadDesired[T any](dir string, nameFn func(T) string) (map[string]desiredFi
 			hash:   hex.EncodeToString(h[:]),
 		}
 	}
+
 	return result, blocked, errs
 }
 
 func (s *Service) loadManaged(entityType model.EntityType) (map[string]model.ManagedConfigFile, error) {
 	var rows []model.ManagedConfigFile
-	if err := s.services.DB.Where("entity_type = ?", entityType).Find(&rows).Error; err != nil {
+	if err := s.db.Where("entity_type = ?", entityType).Find(&rows).Error; err != nil {
 		return nil, err
 	}
 	out := make(map[string]model.ManagedConfigFile, len(rows))
@@ -271,12 +284,12 @@ func toJSON(v any) (datatypes.JSON, error) {
 
 func (s *Service) createOrUpdateManagedRow(entityType model.EntityType, name, path, hash string) error {
 	var row model.ManagedConfigFile
-	err := s.services.DB.Where("entity_type = ? AND entity_name = ?", entityType, name).First(&row).Error
+	err := s.db.Where("entity_type = ? AND entity_name = ?", entityType, name).First(&row).Error
 	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 		return err
 	}
 	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return s.services.DB.Create(&model.ManagedConfigFile{
+		return s.db.Create(&model.ManagedConfigFile{
 			EntityType: entityType,
 			EntityName: name,
 			FilePath:   path,
@@ -285,22 +298,26 @@ func (s *Service) createOrUpdateManagedRow(entityType model.EntityType, name, pa
 	}
 	row.FilePath = path
 	row.FileHash = hash
-	return s.services.DB.Save(&row).Error
+	return s.db.Save(&row).Error
 }
 
 func (s *Service) deleteManagedRow(entityType model.EntityType, name string) error {
-	return s.services.DB.Unscoped().Where("entity_type = ? AND entity_name = ?", entityType, name).Delete(&model.ManagedConfigFile{}).Error
+	return s.db.Unscoped().Where("entity_type = ? AND entity_name = ?", entityType, name).Delete(&model.ManagedConfigFile{}).Error
 }
 
 func (s *Service) reconcileMcpServers(ctx context.Context) error {
 	desired, blocked, parseErrs := loadDesired[types.RegisterServerInput](filepath.Join(s.opts.Dir, types.ConfigSyncMcpServersDirName), func(i types.RegisterServerInput) string { return i.Name })
+
 	managed, err := s.loadManaged(model.EntityTypeMcpServer)
 	if err != nil {
 		return fmt.Errorf("failed to load tracked mcp server configs: %w", err)
 	}
+
 	var errs []error
 	errs = append(errs, parseErrs...)
 
+	// for each desired mcp server config, ensure the corresponding server exists with the correct attributes
+	// also track the desired state config if not already tracked
 	for name, d := range desired {
 		transport, err := types.ValidateTransport(d.entity.Transport)
 		if err != nil {
@@ -309,7 +326,7 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 		}
 		sessionMode, err := types.ValidateSessionMode(d.entity.SessionMode)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid session_mode in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("invalid session mode in %s: %w", d.path, err))
 			continue
 		}
 		server, err := newServerFromInput(d.entity, transport, sessionMode)
@@ -361,6 +378,8 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 		}
 	}
 
+	// for each tracked mcp server config, if the corresponding config file is now missing and there are no errors
+	// blocking deletion, delete the server and stop tracking its config
 	for name, trackedRow := range managed {
 		if _, ok := desired[name]; ok {
 			continue
@@ -400,20 +419,25 @@ func serverEqual(a, b *model.McpServer) bool {
 
 func (s *Service) reconcileMcpClients() error {
 	desired, blocked, parseErrs := loadDesired[types.McpClientConfig](filepath.Join(s.opts.Dir, types.ConfigSyncMcpClientsDirName), func(i types.McpClientConfig) string { return i.Name })
+
 	managed, err := s.loadManaged(model.EntityTypeMcpClient)
 	if err != nil {
 		return err
 	}
+
 	var errs []error
 	errs = append(errs, parseErrs...)
 
+	// for each desired mcp client config, ensure the corresponding client exists with the correct attributes
+	// also track the desired state config if not already tracked
 	for name, d := range desired {
 		allowJSON, err := toJSON(d.entity.AllowMcpServers)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("invalid allow list in %s: %w", d.path, err))
 			continue
 		}
-		accessToken, err := resolveAccessTokenFromConfig(d.entity.AccessToken, d.entity.AccessTokenRef)
+
+		accessToken, err := d.entity.AccessTokenRef.ResolveAccessToken(d.entity.AccessToken)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.path, err))
 			continue
@@ -423,38 +447,46 @@ func (s *Service) reconcileMcpClients() error {
 			continue
 		}
 
-		var existing model.McpClient
-		err = s.services.DB.Where("name = ?", name).First(&existing).Error
+		existing, err := s.services.MCPClientService.GetClient(name)
 		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
 			errs = append(errs, fmt.Errorf("failed to fetch mcp client %s: %w", name, err))
 			continue
 		}
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			if err := s.services.DB.Create(&model.McpClient{
+			// client is desired but doesn't yet exist, create it
+			newClient := model.McpClient{
 				Name:        name,
 				Description: d.entity.Description,
 				AccessToken: accessToken,
 				AllowList:   allowJSON,
-			}).Error; err != nil {
+			}
+			_, createClientErr := s.services.MCPClientService.CreateClient(newClient)
+			if createClientErr != nil {
 				errs = append(errs, fmt.Errorf("failed to create mcp client %s: %w", name, err))
 				continue
 			}
 		} else {
+			// by this point, the client definitely exists. check for updates to any attributes.
 			if existing.Description != d.entity.Description || existing.AccessToken != accessToken || !slices.Equal(existing.AllowList, allowJSON) {
 				existing.Description = d.entity.Description
 				existing.AccessToken = accessToken
 				existing.AllowList = allowJSON
-				if err := s.services.DB.Save(&existing).Error; err != nil {
+
+				_, err := s.services.MCPClientService.UpdateClient(*existing)
+				if err != nil {
 					errs = append(errs, fmt.Errorf("failed to update mcp client %s: %w", name, err))
 					continue
 				}
 			}
 		}
+
 		if err := s.createOrUpdateManagedRow(model.EntityTypeMcpClient, name, d.path, d.hash); err != nil {
 			errs = append(errs, fmt.Errorf("failed to track mcp client %s: %w", name, err))
 		}
 	}
 
+	// for each tracked mcp client config, if the corresponding config file is now missing and there are no errors
+	// blocking deletion, delete the client and stop tracking its config
 	for name, trackedRow := range managed {
 		if _, ok := desired[name]; ok {
 			continue
@@ -462,7 +494,9 @@ func (s *Service) reconcileMcpClients() error {
 		if blocked[trackedRow.FilePath] || fileExists(trackedRow.FilePath) {
 			continue
 		}
-		if err := s.services.DB.Unscoped().Where("name = ?", name).Delete(&model.McpClient{}).Error; err != nil {
+
+		// client is no longer desired, delete it and stop tracking
+		if err := s.services.MCPClientService.DeleteClient(name); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete managed mcp client %s after file removal: %w", name, err))
 			continue
 		}
@@ -470,6 +504,7 @@ func (s *Service) reconcileMcpClients() error {
 			errs = append(errs, fmt.Errorf("failed to remove tracking for mcp client %s: %w", name, err))
 		}
 	}
+
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
@@ -478,34 +513,50 @@ func (s *Service) reconcileMcpClients() error {
 
 func (s *Service) reconcileGroups() error {
 	desired, blocked, parseErrs := loadDesired[types.ToolGroup](filepath.Join(s.opts.Dir, types.ConfigSyncGroupsDirName), func(i types.ToolGroup) string { return i.Name })
+
 	managed, err := s.loadManaged(model.EntityTypeGroup)
 	if err != nil {
 		return err
 	}
+
 	var errs []error
 	errs = append(errs, parseErrs...)
 
+	// for each desired group config, ensure the corresponding group exists with the correct attributes
+	// also track the desired state config if not already tracked
 	for name, d := range desired {
 		incTools, err := toJSON(d.entity.IncludedTools)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("invalid included_tools in %s: %w", d.path, err))
 			continue
 		}
+
 		incServers, err := toJSON(d.entity.IncludedServers)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("invalid included_servers in %s: %w", d.path, err))
 			continue
 		}
+
 		exclTools, err := toJSON(d.entity.ExcludedTools)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("invalid excluded_tools in %s: %w", d.path, err))
 			continue
 		}
-		groupModel := &model.ToolGroup{Name: name, Description: d.entity.Description, IncludedTools: incTools, IncludedServers: incServers, ExcludedTools: exclTools}
+
+		groupModel := &model.ToolGroup{
+			Name:            name,
+			Description:     d.entity.Description,
+			IncludedTools:   incTools,
+			IncludedServers: incServers,
+			ExcludedTools:   exclTools,
+		}
+
 		_, tracked := managed[name]
+
 		old, err := s.services.ToolGroupService.GetToolGroup(name)
 		if err != nil {
 			if errors.Is(err, toolgroup.ErrToolGroupNotFound) {
+				// group is desired but doesn't yet exist, create it
 				if err := s.services.ToolGroupService.CreateToolGroup(groupModel); err != nil {
 					errs = append(errs, fmt.Errorf("failed to create group %s from %s: %w", name, d.path, err))
 					continue
@@ -516,16 +567,23 @@ func (s *Service) reconcileGroups() error {
 			}
 		} else {
 			if !tracked || !groupEqual(old, groupModel) {
+				// group exists but is either not tracked (manually created) or has drifted from the desired state,
+				// update it
 				if _, err := s.services.ToolGroupService.UpdateToolGroup(name, groupModel); err != nil {
 					errs = append(errs, fmt.Errorf("failed to update group %s from %s: %w", name, d.path, err))
 					continue
 				}
 			}
 		}
+
+		// by this point, the group definitely exists and is up to date. if it's not tracked already, track it now.
 		if err := s.createOrUpdateManagedRow(model.EntityTypeGroup, name, d.path, d.hash); err != nil {
 			errs = append(errs, fmt.Errorf("failed to track group %s: %w", name, err))
 		}
 	}
+
+	// for each tracked group config, if the corresponding config file is now missing and there are no errors
+	// blocking deletion, delete the group and stop tracking its config
 	for name, trackedRow := range managed {
 		if _, ok := desired[name]; ok {
 			continue
@@ -533,6 +591,7 @@ func (s *Service) reconcileGroups() error {
 		if blocked[trackedRow.FilePath] || fileExists(trackedRow.FilePath) {
 			continue
 		}
+
 		if err := s.services.ToolGroupService.DeleteToolGroup(name); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete managed group %s after file removal: %w", name, err))
 			continue
@@ -541,27 +600,37 @@ func (s *Service) reconcileGroups() error {
 			errs = append(errs, fmt.Errorf("failed to remove tracking for group %s: %w", name, err))
 		}
 	}
+
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 	return nil
 }
 
+// groupEqual compares two ToolGroup models for equality based on their relevant fields.
 func groupEqual(a, b *model.ToolGroup) bool {
 	return a.Name == b.Name && a.Description == b.Description && slices.Equal(a.IncludedTools, b.IncludedTools) && slices.Equal(a.IncludedServers, b.IncludedServers) && slices.Equal(a.ExcludedTools, b.ExcludedTools)
 }
 
+// reconcileUsers syncs user accounts based on config files in the users directory.
 func (s *Service) reconcileUsers() error {
-	desired, blocked, parseErrs := loadDesired[types.UserConfig](filepath.Join(s.opts.Dir, types.ConfigSyncUsersDirName), func(i types.UserConfig) string { return i.Username })
+	// load the desired state of all users
+	userDir := filepath.Join(s.opts.Dir, types.ConfigSyncUsersDirName)
+	desired, blocked, parseErrs := loadDesired[types.UserConfig](userDir, func(i types.UserConfig) string { return i.Username })
+
+	// load the current state of all users from db
 	managed, err := s.loadManaged(model.EntityTypeUser)
 	if err != nil {
 		return err
 	}
+
 	var errs []error
 	errs = append(errs, parseErrs...)
 
+	// for each desired user config, ensure the corresponding user exists with the correct attributes
+	// also track the desired state config if not already tracked
 	for name, d := range desired {
-		accessToken, err := resolveAccessTokenFromConfig(d.entity.AccessToken, d.entity.AccessTokenRef)
+		accessToken, err := d.entity.AccessTokenRef.ResolveAccessToken(d.entity.AccessToken)
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.path, err))
 			continue
@@ -571,28 +640,34 @@ func (s *Service) reconcileUsers() error {
 			continue
 		}
 
-		var existing model.User
-		err = s.services.DB.Where("username = ?", name).First(&existing).Error
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
-			errs = append(errs, fmt.Errorf("failed to fetch user %s: %w", name, err))
-			continue
-		}
-		if errors.Is(err, gorm.ErrRecordNotFound) {
-			if err := s.services.DB.Create(&model.User{Username: name, Role: types.UserRoleUser, AccessToken: accessToken}).Error; err != nil {
+		existing, err := s.services.UserService.GetUser(name)
+		if err != nil {
+			if !errors.Is(err, gorm.ErrRecordNotFound) {
+				// unexpected error
+				errs = append(errs, fmt.Errorf("failed to fetch user %s: %w", name, err))
+				continue
+			}
+
+			// user doesn't exist in db, create one
+			newUser := &model.User{Username: name, AccessToken: accessToken}
+			_, err := s.services.UserService.CreateUser(newUser)
+			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to create user %s: %w", name, err))
 				continue
 			}
-		} else {
-			if existing.Role == types.UserRoleAdmin {
-				errs = append(errs, fmt.Errorf("config sync cannot manage admin user %s (file: %s)", name, d.path))
+		}
+
+		// by this point, the user definitely exists. check for updates to any attributes.
+		if existing.Role == types.UserRoleAdmin {
+			errs = append(errs, fmt.Errorf("config sync cannot manage admin user %s (file: %s)", name, d.path))
+			continue
+		}
+		if existing.AccessToken != accessToken {
+			existing.AccessToken = accessToken
+			_, err := s.services.UserService.UpdateUser(existing)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("failed to update user %s: %w", name, err))
 				continue
-			}
-			if existing.AccessToken != accessToken {
-				existing.AccessToken = accessToken
-				if err := s.services.DB.Save(&existing).Error; err != nil {
-					errs = append(errs, fmt.Errorf("failed to update user %s: %w", name, err))
-					continue
-				}
 			}
 		}
 
@@ -600,6 +675,9 @@ func (s *Service) reconcileUsers() error {
 			errs = append(errs, fmt.Errorf("failed to track user %s: %w", name, err))
 		}
 	}
+
+	// for each tracked user config, if the corresponding config file is now missing and there are no errors
+	// blocking deletion, delete the user and stop tracking it
 	for name, trackedRow := range managed {
 		if _, ok := desired[name]; ok {
 			continue
@@ -607,20 +685,26 @@ func (s *Service) reconcileUsers() error {
 		if blocked[trackedRow.FilePath] || fileExists(trackedRow.FilePath) {
 			continue
 		}
-		var user model.User
-		if err := s.services.DB.Where("username = ?", name).First(&user).Error; err != nil {
+
+		// the user is no longer desired at this point
+		managedUser, err := s.services.UserService.GetUser(name)
+		if err != nil {
 			if errors.Is(err, gorm.ErrRecordNotFound) {
+				// if the user is already gone, stop tracking its config in the system as well
 				_ = s.deleteManagedRow(model.EntityTypeUser, name)
 				continue
 			}
 			errs = append(errs, fmt.Errorf("failed to fetch managed user %s during deletion: %w", name, err))
 			continue
 		}
-		if user.Role == types.UserRoleAdmin {
+
+		if managedUser.Role == types.UserRoleAdmin {
 			errs = append(errs, fmt.Errorf("config sync cannot delete admin user %s", name))
 			continue
 		}
-		if err := s.services.DB.Unscoped().Where("username = ?", name).Delete(&model.User{}).Error; err != nil {
+
+		// delete the user and stop tracking its config
+		if err := s.services.UserService.DeleteUser(name); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete managed user %s after file removal: %w", name, err))
 			continue
 		}
@@ -628,46 +712,18 @@ func (s *Service) reconcileUsers() error {
 			errs = append(errs, fmt.Errorf("failed to remove tracking for user %s: %w", name, err))
 		}
 	}
+
 	if len(errs) > 0 {
 		return errors.Join(errs...)
 	}
 	return nil
 }
 
+// fileExists checks if a file exists at the given path. It returns false if the path is empty or only whitespace.
 func fileExists(path string) bool {
 	if strings.TrimSpace(path) == "" {
 		return false
 	}
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-func resolveAccessTokenFromConfig(accessToken string, ref types.AccessTokenRef) (string, error) {
-	if strings.TrimSpace(accessToken) != "" {
-		return strings.TrimSpace(accessToken), nil
-	}
-	if strings.TrimSpace(ref.Env) != "" {
-		v, ok := os.LookupEnv(ref.Env)
-		if ok {
-			v = strings.TrimSpace(v)
-			if v != "" {
-				return v, nil
-			}
-		}
-		if strings.TrimSpace(ref.File) == "" {
-			return "", fmt.Errorf("environment variable %s is not set or empty", ref.Env)
-		}
-	}
-	if strings.TrimSpace(ref.File) != "" {
-		data, err := os.ReadFile(ref.File)
-		if err != nil {
-			return "", fmt.Errorf("failed to read access token file %s: %w", ref.File, err)
-		}
-		v := strings.TrimSpace(string(data))
-		if v == "" {
-			return "", fmt.Errorf("access token file %s is empty", ref.File)
-		}
-		return v, nil
-	}
-	return "", nil
 }

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -19,6 +19,7 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
 	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
 	"github.com/mcpjungle/mcpjungle/internal/service/user"
+	"github.com/mcpjungle/mcpjungle/pkg/accesstoken"
 	"github.com/mcpjungle/mcpjungle/pkg/configfiles"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"gorm.io/datatypes"
@@ -371,7 +372,10 @@ func (s *Service) reconcileMcpClients() error {
 			continue
 		}
 
-		accessToken, err := d.Entity.AccessTokenRef.ResolveAccessToken(d.Entity.AccessToken)
+		accessToken, err := accesstoken.Resolve(accesstoken.Input{
+			Inline: d.Entity.AccessToken,
+			Ref:    d.Entity.AccessTokenRef,
+		})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.Path, err))
 			continue
@@ -564,7 +568,10 @@ func (s *Service) reconcileUsers() error {
 	// for each desired user config, ensure the corresponding user exists with the correct attributes
 	// also track the desired state config if not already tracked
 	for name, d := range desired {
-		accessToken, err := d.Entity.AccessTokenRef.ResolveAccessToken(d.Entity.AccessToken)
+		accessToken, err := accesstoken.Resolve(accesstoken.Input{
+			Inline: d.Entity.AccessToken,
+			Ref:    d.Entity.AccessTokenRef,
+		})
 		if err != nil {
 			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.Path, err))
 			continue

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -2,8 +2,6 @@ package configsync
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -21,6 +19,7 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
 	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
 	"github.com/mcpjungle/mcpjungle/internal/service/user"
+	"github.com/mcpjungle/mcpjungle/pkg/configfiles"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
@@ -197,71 +196,6 @@ func (s *Service) Reconcile(ctx context.Context) error {
 	return nil
 }
 
-// desiredFile represents a config file on disk that we want to be reflected in the system.
-type desiredFile[T any] struct {
-	entity   T
-	name     string
-	path     string
-	hash     string
-	parseErr error
-}
-
-// loadDesired reads config files from the specified directory, parses them into entities of type T, and returns
-// a map of entity name to desiredFile.
-// It also returns a map of file paths that had errors during loading (either read errors or parse errors) to
-// a boolean (the value is not used, we just need a set).
-// If there were any errors during loading, it returns a slice of those errors as well.
-func loadDesired[T any](dir string, nameFn func(T) string) (map[string]desiredFile[T], map[string]bool, []error) {
-	entries, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, nil, []error{fmt.Errorf("failed to read directory %s: %w", dir, err)}
-	}
-
-	result := map[string]desiredFile[T]{}
-	blocked := map[string]bool{}
-	var errs []error
-
-	for _, e := range entries {
-		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
-			continue
-		}
-		full := filepath.Join(dir, e.Name())
-		raw, err := os.ReadFile(full)
-		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to read config file %s: %w", full, err))
-			blocked[full] = true
-			continue
-		}
-		var conf T
-		if err := json.Unmarshal(raw, &conf); err != nil {
-			errs = append(errs, fmt.Errorf("invalid JSON in %s: %w", full, err))
-			blocked[full] = true
-			continue
-		}
-		name := strings.TrimSpace(nameFn(conf))
-		if name == "" {
-			errs = append(errs, fmt.Errorf("config file %s does not define a valid name", full))
-			blocked[full] = true
-			continue
-		}
-		if existing, ok := result[name]; ok {
-			errs = append(errs, fmt.Errorf("conflict: duplicate %s defined by %s and %s", name, existing.path, full))
-			blocked[full] = true
-			blocked[existing.path] = true
-			continue
-		}
-		h := sha256.Sum256(raw)
-		result[name] = desiredFile[T]{
-			entity: conf,
-			name:   name,
-			path:   full,
-			hash:   hex.EncodeToString(h[:]),
-		}
-	}
-
-	return result, blocked, errs
-}
-
 func (s *Service) loadManaged(entityType model.EntityType) (map[string]model.ManagedConfigFile, error) {
 	var rows []model.ManagedConfigFile
 	if err := s.db.Where("entity_type = ?", entityType).Find(&rows).Error; err != nil {
@@ -306,7 +240,7 @@ func (s *Service) deleteManagedRow(entityType model.EntityType, name string) err
 }
 
 func (s *Service) reconcileMcpServers(ctx context.Context) error {
-	desired, blocked, parseErrs := loadDesired[types.RegisterServerInput](filepath.Join(s.opts.Dir, types.ConfigSyncMcpServersDirName), func(i types.RegisterServerInput) string { return i.Name })
+	desired, blocked, parseErrs := configfiles.LoadDesired[types.RegisterServerInput](filepath.Join(s.opts.Dir, types.ConfigSyncMcpServersDirName), func(i types.RegisterServerInput) string { return i.Name })
 
 	managed, err := s.loadManaged(model.EntityTypeMcpServer)
 	if err != nil {
@@ -319,19 +253,19 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 	// for each desired mcp server config, ensure the corresponding server exists with the correct attributes
 	// also track the desired state config if not already tracked
 	for name, d := range desired {
-		transport, err := types.ValidateTransport(d.entity.Transport)
+		transport, err := types.ValidateTransport(d.Entity.Transport)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid transport in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("invalid transport in %s: %w", d.Path, err))
 			continue
 		}
-		sessionMode, err := types.ValidateSessionMode(d.entity.SessionMode)
+		sessionMode, err := types.ValidateSessionMode(d.Entity.SessionMode)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid session mode in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("invalid session mode in %s: %w", d.Path, err))
 			continue
 		}
-		server, err := newServerFromInput(d.entity, transport, sessionMode)
+		server, err := newServerFromInput(d.Entity, transport, sessionMode)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid mcp server config in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("invalid mcp server config in %s: %w", d.Path, err))
 			continue
 		}
 
@@ -344,10 +278,10 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 		track, tracked := managed[name]
 		if errors.Is(getErr, mcp.ErrMCPServerNotFound) {
 			if err := s.services.MCPService.RegisterMcpServer(ctx, server); err != nil {
-				errs = append(errs, fmt.Errorf("failed to create mcp server %s from %s: %w", name, d.path, err))
+				errs = append(errs, fmt.Errorf("failed to create mcp server %s from %s: %w", name, d.Path, err))
 				continue
 			}
-			if err := s.createOrUpdateManagedRow(model.EntityTypeMcpServer, name, d.path, d.hash); err != nil {
+			if err := s.createOrUpdateManagedRow(model.EntityTypeMcpServer, name, d.Path, d.Hash); err != nil {
 				errs = append(errs, fmt.Errorf("failed to track mcp server %s: %w", name, err))
 			}
 			continue
@@ -359,7 +293,7 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 			track = model.ManagedConfigFile{EntityName: name}
 		}
 
-		if tracked && track.FileHash == d.hash {
+		if tracked && track.FileHash == d.Hash {
 			continue
 		}
 
@@ -369,11 +303,11 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 				continue
 			}
 			if err := s.services.MCPService.RegisterMcpServer(ctx, server); err != nil {
-				errs = append(errs, fmt.Errorf("failed to register updated mcp server %s from %s: %w", name, d.path, err))
+				errs = append(errs, fmt.Errorf("failed to register updated mcp server %s from %s: %w", name, d.Path, err))
 				continue
 			}
 		}
-		if err := s.createOrUpdateManagedRow(model.EntityTypeMcpServer, name, d.path, d.hash); err != nil {
+		if err := s.createOrUpdateManagedRow(model.EntityTypeMcpServer, name, d.Path, d.Hash); err != nil {
 			errs = append(errs, fmt.Errorf("failed to track mcp server %s: %w", name, err))
 		}
 	}
@@ -418,7 +352,7 @@ func serverEqual(a, b *model.McpServer) bool {
 }
 
 func (s *Service) reconcileMcpClients() error {
-	desired, blocked, parseErrs := loadDesired[types.McpClientConfig](filepath.Join(s.opts.Dir, types.ConfigSyncMcpClientsDirName), func(i types.McpClientConfig) string { return i.Name })
+	desired, blocked, parseErrs := configfiles.LoadDesired[types.McpClientConfig](filepath.Join(s.opts.Dir, types.ConfigSyncMcpClientsDirName), func(i types.McpClientConfig) string { return i.Name })
 
 	managed, err := s.loadManaged(model.EntityTypeMcpClient)
 	if err != nil {
@@ -431,19 +365,19 @@ func (s *Service) reconcileMcpClients() error {
 	// for each desired mcp client config, ensure the corresponding client exists with the correct attributes
 	// also track the desired state config if not already tracked
 	for name, d := range desired {
-		allowJSON, err := toJSON(d.entity.AllowMcpServers)
+		allowJSON, err := toJSON(d.Entity.AllowMcpServers)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid allow list in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("invalid allow list in %s: %w", d.Path, err))
 			continue
 		}
 
-		accessToken, err := d.entity.AccessTokenRef.ResolveAccessToken(d.entity.AccessToken)
+		accessToken, err := d.Entity.AccessTokenRef.ResolveAccessToken(d.Entity.AccessToken)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.Path, err))
 			continue
 		}
 		if accessToken == "" {
-			errs = append(errs, fmt.Errorf("mcp client config %s must provide access token or access_token_ref", d.path))
+			errs = append(errs, fmt.Errorf("mcp client config %s must provide access token or access_token_ref", d.Path))
 			continue
 		}
 
@@ -456,7 +390,7 @@ func (s *Service) reconcileMcpClients() error {
 			// client is desired but doesn't yet exist, create it
 			newClient := model.McpClient{
 				Name:        name,
-				Description: d.entity.Description,
+				Description: d.Entity.Description,
 				AccessToken: accessToken,
 				AllowList:   allowJSON,
 			}
@@ -467,8 +401,8 @@ func (s *Service) reconcileMcpClients() error {
 			}
 		} else {
 			// by this point, the client definitely exists. check for updates to any attributes.
-			if existing.Description != d.entity.Description || existing.AccessToken != accessToken || !slices.Equal(existing.AllowList, allowJSON) {
-				existing.Description = d.entity.Description
+			if existing.Description != d.Entity.Description || existing.AccessToken != accessToken || !slices.Equal(existing.AllowList, allowJSON) {
+				existing.Description = d.Entity.Description
 				existing.AccessToken = accessToken
 				existing.AllowList = allowJSON
 
@@ -480,7 +414,7 @@ func (s *Service) reconcileMcpClients() error {
 			}
 		}
 
-		if err := s.createOrUpdateManagedRow(model.EntityTypeMcpClient, name, d.path, d.hash); err != nil {
+		if err := s.createOrUpdateManagedRow(model.EntityTypeMcpClient, name, d.Path, d.Hash); err != nil {
 			errs = append(errs, fmt.Errorf("failed to track mcp client %s: %w", name, err))
 		}
 	}
@@ -512,7 +446,7 @@ func (s *Service) reconcileMcpClients() error {
 }
 
 func (s *Service) reconcileGroups() error {
-	desired, blocked, parseErrs := loadDesired[types.ToolGroup](filepath.Join(s.opts.Dir, types.ConfigSyncGroupsDirName), func(i types.ToolGroup) string { return i.Name })
+	desired, blocked, parseErrs := configfiles.LoadDesired[types.ToolGroup](filepath.Join(s.opts.Dir, types.ConfigSyncGroupsDirName), func(i types.ToolGroup) string { return i.Name })
 
 	managed, err := s.loadManaged(model.EntityTypeGroup)
 	if err != nil {
@@ -525,27 +459,27 @@ func (s *Service) reconcileGroups() error {
 	// for each desired group config, ensure the corresponding group exists with the correct attributes
 	// also track the desired state config if not already tracked
 	for name, d := range desired {
-		incTools, err := toJSON(d.entity.IncludedTools)
+		incTools, err := toJSON(d.Entity.IncludedTools)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid included_tools in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("invalid included_tools in %s: %w", d.Path, err))
 			continue
 		}
 
-		incServers, err := toJSON(d.entity.IncludedServers)
+		incServers, err := toJSON(d.Entity.IncludedServers)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid included_servers in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("invalid included_servers in %s: %w", d.Path, err))
 			continue
 		}
 
-		exclTools, err := toJSON(d.entity.ExcludedTools)
+		exclTools, err := toJSON(d.Entity.ExcludedTools)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("invalid excluded_tools in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("invalid excluded_tools in %s: %w", d.Path, err))
 			continue
 		}
 
 		groupModel := &model.ToolGroup{
 			Name:            name,
-			Description:     d.entity.Description,
+			Description:     d.Entity.Description,
 			IncludedTools:   incTools,
 			IncludedServers: incServers,
 			ExcludedTools:   exclTools,
@@ -558,7 +492,7 @@ func (s *Service) reconcileGroups() error {
 			if errors.Is(err, toolgroup.ErrToolGroupNotFound) {
 				// group is desired but doesn't yet exist, create it
 				if err := s.services.ToolGroupService.CreateToolGroup(groupModel); err != nil {
-					errs = append(errs, fmt.Errorf("failed to create group %s from %s: %w", name, d.path, err))
+					errs = append(errs, fmt.Errorf("failed to create group %s from %s: %w", name, d.Path, err))
 					continue
 				}
 			} else {
@@ -570,14 +504,14 @@ func (s *Service) reconcileGroups() error {
 				// group exists but is either not tracked (manually created) or has drifted from the desired state,
 				// update it
 				if _, err := s.services.ToolGroupService.UpdateToolGroup(name, groupModel); err != nil {
-					errs = append(errs, fmt.Errorf("failed to update group %s from %s: %w", name, d.path, err))
+					errs = append(errs, fmt.Errorf("failed to update group %s from %s: %w", name, d.Path, err))
 					continue
 				}
 			}
 		}
 
 		// by this point, the group definitely exists and is up to date. if it's not tracked already, track it now.
-		if err := s.createOrUpdateManagedRow(model.EntityTypeGroup, name, d.path, d.hash); err != nil {
+		if err := s.createOrUpdateManagedRow(model.EntityTypeGroup, name, d.Path, d.Hash); err != nil {
 			errs = append(errs, fmt.Errorf("failed to track group %s: %w", name, err))
 		}
 	}
@@ -616,7 +550,7 @@ func groupEqual(a, b *model.ToolGroup) bool {
 func (s *Service) reconcileUsers() error {
 	// load the desired state of all users
 	userDir := filepath.Join(s.opts.Dir, types.ConfigSyncUsersDirName)
-	desired, blocked, parseErrs := loadDesired[types.UserConfig](userDir, func(i types.UserConfig) string { return i.Username })
+	desired, blocked, parseErrs := configfiles.LoadDesired[types.UserConfig](userDir, func(i types.UserConfig) string { return i.Username })
 
 	// load the current state of all users from db
 	managed, err := s.loadManaged(model.EntityTypeUser)
@@ -630,13 +564,13 @@ func (s *Service) reconcileUsers() error {
 	// for each desired user config, ensure the corresponding user exists with the correct attributes
 	// also track the desired state config if not already tracked
 	for name, d := range desired {
-		accessToken, err := d.entity.AccessTokenRef.ResolveAccessToken(d.entity.AccessToken)
+		accessToken, err := d.Entity.AccessTokenRef.ResolveAccessToken(d.Entity.AccessToken)
 		if err != nil {
-			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.path, err))
+			errs = append(errs, fmt.Errorf("failed to resolve access token in %s: %w", d.Path, err))
 			continue
 		}
 		if accessToken == "" {
-			errs = append(errs, fmt.Errorf("user config %s must provide access token or access_token_ref", d.path))
+			errs = append(errs, fmt.Errorf("user config %s must provide access token or access_token_ref", d.Path))
 			continue
 		}
 
@@ -660,7 +594,7 @@ func (s *Service) reconcileUsers() error {
 
 		// by this point, the user definitely exists. check for updates to any attributes.
 		if existing.Role == types.UserRoleAdmin {
-			errs = append(errs, fmt.Errorf("config sync cannot manage admin user %s (file: %s)", name, d.path))
+			errs = append(errs, fmt.Errorf("config sync cannot manage admin user %s (file: %s)", name, d.Path))
 			continue
 		}
 		if existing.AccessToken != accessToken {
@@ -672,7 +606,7 @@ func (s *Service) reconcileUsers() error {
 			}
 		}
 
-		if err := s.createOrUpdateManagedRow(model.EntityTypeUser, name, d.path, d.hash); err != nil {
+		if err := s.createOrUpdateManagedRow(model.EntityTypeUser, name, d.Path, d.Hash); err != nil {
 			errs = append(errs, fmt.Errorf("failed to track user %s: %w", name, err))
 		}
 	}

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -294,7 +294,7 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 			track = model.ManagedConfigFile{EntityName: name}
 		}
 
-		if tracked && track.FileHash == d.Hash {
+		if track.FileHash == d.Hash {
 			continue
 		}
 

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -336,13 +336,13 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 		}
 
 		existing, getErr := s.services.MCPService.GetMcpServer(name)
-		if getErr != nil && !errors.Is(getErr, gorm.ErrRecordNotFound) {
+		if getErr != nil && !errors.Is(getErr, mcp.ErrMCPServerNotFound) {
 			errs = append(errs, fmt.Errorf("failed to read mcp server %s: %w", name, getErr))
 			continue
 		}
 
 		track, tracked := managed[name]
-		if errors.Is(getErr, gorm.ErrRecordNotFound) {
+		if errors.Is(getErr, mcp.ErrMCPServerNotFound) {
 			if err := s.services.MCPService.RegisterMcpServer(ctx, server); err != nil {
 				errs = append(errs, fmt.Errorf("failed to create mcp server %s from %s: %w", name, d.path, err))
 				continue
@@ -448,11 +448,11 @@ func (s *Service) reconcileMcpClients() error {
 		}
 
 		existing, err := s.services.MCPClientService.GetClient(name)
-		if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+		if err != nil && !errors.Is(err, mcpclient.ErrMCPClientNotFound) {
 			errs = append(errs, fmt.Errorf("failed to fetch mcp client %s: %w", name, err))
 			continue
 		}
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+		if errors.Is(err, mcpclient.ErrMCPClientNotFound) {
 			// client is desired but doesn't yet exist, create it
 			newClient := model.McpClient{
 				Name:        name,
@@ -642,7 +642,7 @@ func (s *Service) reconcileUsers() error {
 
 		existing, err := s.services.UserService.GetUser(name)
 		if err != nil {
-			if !errors.Is(err, gorm.ErrRecordNotFound) {
+			if !errors.Is(err, user.ErrUserNotFound) {
 				// unexpected error
 				errs = append(errs, fmt.Errorf("failed to fetch user %s: %w", name, err))
 				continue
@@ -650,11 +650,12 @@ func (s *Service) reconcileUsers() error {
 
 			// user doesn't exist in db, create one
 			newUser := &model.User{Username: name, AccessToken: accessToken}
-			_, err := s.services.UserService.CreateUser(newUser)
+			createdUser, err := s.services.UserService.CreateUser(newUser)
 			if err != nil {
 				errs = append(errs, fmt.Errorf("failed to create user %s: %w", name, err))
 				continue
 			}
+			existing = createdUser
 		}
 
 		// by this point, the user definitely exists. check for updates to any attributes.
@@ -689,7 +690,7 @@ func (s *Service) reconcileUsers() error {
 		// the user is no longer desired at this point
 		managedUser, err := s.services.UserService.GetUser(name)
 		if err != nil {
-			if errors.Is(err, gorm.ErrRecordNotFound) {
+			if errors.Is(err, user.ErrUserNotFound) {
 				// if the user is already gone, stop tracking its config in the system as well
 				_ = s.deleteManagedRow(model.EntityTypeUser, name)
 				continue

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -241,7 +241,11 @@ func (s *Service) deleteManagedRow(entityType model.EntityType, name string) err
 }
 
 func (s *Service) reconcileMcpServers(ctx context.Context) error {
-	desired, blocked, parseErrs := configfiles.LoadDesired[types.RegisterServerInput](filepath.Join(s.opts.Dir, types.ConfigSyncMcpServersDirName), func(i types.RegisterServerInput) string { return i.Name })
+	mcpServersDir := filepath.Join(s.opts.Dir, types.ConfigSyncMcpServersDirName)
+	desired, blocked, parseErrs := configfiles.LoadDesired[types.RegisterServerInput](
+		mcpServersDir,
+		func(i types.RegisterServerInput) string { return i.Name },
+	)
 
 	managed, err := s.loadManaged(model.EntityTypeMcpServer)
 	if err != nil {
@@ -278,6 +282,7 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 
 		track, tracked := managed[name]
 		if errors.Is(getErr, mcp.ErrMCPServerNotFound) {
+			// server is desired but doesn't yet exist, create it and start tracking it
 			if err := s.services.MCPService.RegisterMcpServer(ctx, server); err != nil {
 				errs = append(errs, fmt.Errorf("failed to create mcp server %s from %s: %w", name, d.Path, err))
 				continue
@@ -288,17 +293,14 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 			continue
 		}
 
-		if !tracked {
-			// adopt existing manually managed entity
-			tracked = true
-			track = model.ManagedConfigFile{EntityName: name}
-		}
-
-		if track.FileHash == d.Hash {
+		if tracked && track.FileHash == d.Hash {
+			// server is already tracked and the config hasn't changed since the last time we applied it,
+			// so we can skip any updates for this server
 			continue
 		}
 
 		if !serverEqual(existing, server) {
+			// server exists but is different from the desired state, update it.
 			if err := s.services.MCPService.DeregisterMcpServer(name); err != nil {
 				errs = append(errs, fmt.Errorf("failed to deregister mcp server %s for update: %w", name, err))
 				continue
@@ -337,6 +339,7 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 	return nil
 }
 
+// newServerFromInput creates a model.McpServer from the given RegisterServerInput, transport, and session mode.
 func newServerFromInput(input types.RegisterServerInput, transport types.McpServerTransport, sessionMode types.SessionMode) (*model.McpServer, error) {
 	switch transport {
 	case types.TransportStreamableHTTP:

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -104,6 +104,7 @@ func (s *Service) Stop() {
 	if !s.opts.Enabled {
 		return
 	}
+	log.Printf("[config-sync] stopping configuration syncing")
 	if s.cancel != nil {
 		s.cancel()
 	}
@@ -217,6 +218,14 @@ func toJSON(v any) (datatypes.JSON, error) {
 	return datatypes.JSON(b), nil
 }
 
+func logDesiredConfigChange(entityType, action, name, path string) {
+	if strings.TrimSpace(path) == "" {
+		log.Printf("[config-sync] desired config change: %s %s %q", action, entityType, name)
+		return
+	}
+	log.Printf("[config-sync] desired config change: %s %s %q (source: %s)", action, entityType, name, path)
+}
+
 func (s *Service) createOrUpdateManagedRow(entityType model.EntityType, name, path, hash string) error {
 	var row model.ManagedConfigFile
 	err := s.db.Where("entity_type = ? AND entity_name = ?", entityType, name).First(&row).Error
@@ -283,6 +292,7 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 		track, tracked := managed[name]
 		if errors.Is(getErr, mcp.ErrMCPServerNotFound) {
 			// server is desired but doesn't yet exist, create it and start tracking it
+			logDesiredConfigChange("mcp server", "create", name, d.Path)
 			if err := s.services.MCPService.RegisterMcpServer(ctx, server); err != nil {
 				errs = append(errs, fmt.Errorf("failed to create mcp server %s from %s: %w", name, d.Path, err))
 				continue
@@ -301,6 +311,7 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 
 		if !serverEqual(existing, server) {
 			// server exists but is different from the desired state, update it.
+			logDesiredConfigChange("mcp server", "update", name, d.Path)
 			if err := s.services.MCPService.DeregisterMcpServer(name); err != nil {
 				errs = append(errs, fmt.Errorf("failed to deregister mcp server %s for update: %w", name, err))
 				continue
@@ -324,6 +335,7 @@ func (s *Service) reconcileMcpServers(ctx context.Context) error {
 		if blocked[trackedRow.FilePath] || fileExists(trackedRow.FilePath) {
 			continue
 		}
+		logDesiredConfigChange("mcp server", "delete", name, trackedRow.FilePath)
 		if err := s.services.MCPService.DeregisterMcpServer(name); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete managed mcp server %s after file removal: %w", name, err))
 			continue
@@ -395,6 +407,7 @@ func (s *Service) reconcileMcpClients() error {
 		}
 		if errors.Is(err, mcpclient.ErrMCPClientNotFound) {
 			// client is desired but doesn't yet exist, create it
+			logDesiredConfigChange("mcp client", "create", name, d.Path)
 			newClient := model.McpClient{
 				Name:        name,
 				Description: d.Entity.Description,
@@ -409,6 +422,7 @@ func (s *Service) reconcileMcpClients() error {
 		} else {
 			// by this point, the client definitely exists. check for updates to any attributes.
 			if existing.Description != d.Entity.Description || existing.AccessToken != accessToken || !slices.Equal(existing.AllowList, allowJSON) {
+				logDesiredConfigChange("mcp client", "update", name, d.Path)
 				existing.Description = d.Entity.Description
 				existing.AccessToken = accessToken
 				existing.AllowList = allowJSON
@@ -437,6 +451,7 @@ func (s *Service) reconcileMcpClients() error {
 		}
 
 		// client is no longer desired, delete it and stop tracking
+		logDesiredConfigChange("mcp client", "delete", name, trackedRow.FilePath)
 		if err := s.services.MCPClientService.DeleteClient(name); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete managed mcp client %s after file removal: %w", name, err))
 			continue
@@ -498,6 +513,7 @@ func (s *Service) reconcileGroups() error {
 		if err != nil {
 			if errors.Is(err, toolgroup.ErrToolGroupNotFound) {
 				// group is desired but doesn't yet exist, create it
+				logDesiredConfigChange("group", "create", name, d.Path)
 				if err := s.services.ToolGroupService.CreateToolGroup(groupModel); err != nil {
 					errs = append(errs, fmt.Errorf("failed to create group %s from %s: %w", name, d.Path, err))
 					continue
@@ -510,6 +526,7 @@ func (s *Service) reconcileGroups() error {
 			if !tracked || !groupEqual(old, groupModel) {
 				// group exists but is either not tracked (manually created) or has drifted from the desired state,
 				// update it
+				logDesiredConfigChange("group", "update", name, d.Path)
 				if _, err := s.services.ToolGroupService.UpdateToolGroup(name, groupModel); err != nil {
 					errs = append(errs, fmt.Errorf("failed to update group %s from %s: %w", name, d.Path, err))
 					continue
@@ -533,6 +550,7 @@ func (s *Service) reconcileGroups() error {
 			continue
 		}
 
+		logDesiredConfigChange("group", "delete", name, trackedRow.FilePath)
 		if err := s.services.ToolGroupService.DeleteToolGroup(name); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete managed group %s after file removal: %w", name, err))
 			continue
@@ -593,6 +611,7 @@ func (s *Service) reconcileUsers() error {
 			}
 
 			// user doesn't exist in db, create one
+			logDesiredConfigChange("user", "create", name, d.Path)
 			newUser := &model.User{Username: name, AccessToken: accessToken}
 			createdUser, err := s.services.UserService.CreateUser(newUser)
 			if err != nil {
@@ -608,6 +627,7 @@ func (s *Service) reconcileUsers() error {
 			continue
 		}
 		if existing.AccessToken != accessToken {
+			logDesiredConfigChange("user", "update", name, d.Path)
 			existing.AccessToken = accessToken
 			_, err := s.services.UserService.UpdateUser(existing)
 			if err != nil {
@@ -649,6 +669,7 @@ func (s *Service) reconcileUsers() error {
 		}
 
 		// delete the user and stop tracking its config
+		logDesiredConfigChange("user", "delete", name, trackedRow.FilePath)
 		if err := s.services.UserService.DeleteUser(name); err != nil {
 			errs = append(errs, fmt.Errorf("failed to delete managed user %s after file removal: %w", name, err))
 			continue

--- a/internal/service/configsync/config_sync.go
+++ b/internal/service/configsync/config_sync.go
@@ -28,8 +28,15 @@ import (
 
 // Options configures config directory synchronization.
 type Options struct {
+	// Enabled determines whether config syncing is active. If false, the service will be a no-op.
 	Enabled bool
-	Dir     string
+
+	// Dir is the directory to watch for config files.
+	Dir string
+
+	// EnableEnterpriseEntitySync should be set to true to allow syncing of enterprise entities like mcp clients and users.
+	// If false, those entities will be ignored by the sync process.
+	EnableEnterpriseEntitySync bool
 }
 
 // Services groups the external services that the config sync service depends on to do its job.
@@ -67,6 +74,7 @@ func (s *Service) Start(ctx context.Context) error {
 	if !s.opts.Enabled {
 		return nil
 	}
+	log.Printf("[config-sync] starting configuration syncing")
 	if err := s.ensureSubDirs(); err != nil {
 		return err
 	}
@@ -368,6 +376,10 @@ func serverEqual(a, b *model.McpServer) bool {
 }
 
 func (s *Service) reconcileMcpClients() error {
+	if !s.opts.EnableEnterpriseEntitySync {
+		return nil
+	}
+
 	desired, blocked, parseErrs := configfiles.LoadDesired[types.McpClientConfig](filepath.Join(s.opts.Dir, types.ConfigSyncMcpClientsDirName), func(i types.McpClientConfig) string { return i.Name })
 
 	managed, err := s.loadManaged(model.EntityTypeMcpClient)
@@ -573,6 +585,10 @@ func groupEqual(a, b *model.ToolGroup) bool {
 
 // reconcileUsers syncs user accounts based on config files in the users directory.
 func (s *Service) reconcileUsers() error {
+	if !s.opts.EnableEnterpriseEntitySync {
+		return nil
+	}
+
 	// load the desired state of all users
 	userDir := filepath.Join(s.opts.Dir, types.ConfigSyncUsersDirName)
 	desired, blocked, parseErrs := configfiles.LoadDesired[types.UserConfig](userDir, func(i types.UserConfig) string { return i.Username })

--- a/internal/service/configsync/config_sync_test.go
+++ b/internal/service/configsync/config_sync_test.go
@@ -1,0 +1,104 @@
+package configsync
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/mcpjungle/mcpjungle/internal/migrations"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/pkg/types"
+	"gorm.io/driver/sqlite"
+	"gorm.io/gorm"
+)
+
+func newTestDB(t *testing.T) *gorm.DB {
+	t.Helper()
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	if err != nil {
+		t.Fatalf("failed to open db: %v", err)
+	}
+	if err := migrations.Migrate(db); err != nil {
+		t.Fatalf("failed to migrate db: %v", err)
+	}
+	return db
+}
+
+func TestResolveConfigDir(t *testing.T) {
+	d, err := resolveConfigDir("~/.mcpjungle")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !filepath.IsAbs(d) {
+		t.Fatalf("expected absolute path, got %s", d)
+	}
+}
+
+func TestReconcileUsers_AdminUserIsRejected(t *testing.T) {
+	db := newTestDB(t)
+	tmp := t.TempDir()
+	if err := ensureSubDirs(tmp); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	if err := db.Create(&model.User{Username: "admin", Role: types.UserRoleAdmin, AccessToken: "mcpjungle_test_admin"}).Error; err != nil {
+		t.Fatalf("seed admin: %v", err)
+	}
+	cfg := `{"name":"admin","access_token":"mcpjungle_test_replacement"}`
+	if err := os.WriteFile(filepath.Join(tmp, "users", "admin.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	s := &Service{services: Services{DB: db}, resolvedDir: tmp}
+	err := s.reconcileUsers()
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "cannot manage admin user") {
+		t.Fatalf("expected admin restriction error, got: %v", err)
+	}
+
+	var tracked []model.ManagedConfigFile
+	if err := db.Where("entity_type = ?", entityUser).Find(&tracked).Error; err != nil {
+		t.Fatalf("query tracked: %v", err)
+	}
+	if len(tracked) != 0 {
+		t.Fatalf("expected no tracking rows for admin user, got %d", len(tracked))
+	}
+}
+
+func TestReconcileUsers_AdoptsExistingManualUser(t *testing.T) {
+	db := newTestDB(t)
+	tmp := t.TempDir()
+	if err := ensureSubDirs(tmp); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+	if err := db.Create(&model.User{Username: "alice", Role: types.UserRoleUser, AccessToken: "mcpjungle_test_oldtoken"}).Error; err != nil {
+		t.Fatalf("seed user: %v", err)
+	}
+	cfg := `{"name":"alice","access_token":"mcpjungle_test_newtoken"}`
+	if err := os.WriteFile(filepath.Join(tmp, "users", "alice.json"), []byte(cfg), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	s := &Service{services: Services{DB: db}, resolvedDir: tmp}
+	if err := s.reconcileUsers(); err != nil {
+		t.Fatalf("reconcile users: %v", err)
+	}
+
+	var updated model.User
+	if err := db.Where("username = ?", "alice").First(&updated).Error; err != nil {
+		t.Fatalf("fetch user: %v", err)
+	}
+	if updated.AccessToken != "mcpjungle_test_newtoken" {
+		t.Fatalf("expected token update, got %s", updated.AccessToken)
+	}
+
+	var tracked model.ManagedConfigFile
+	if err := db.Where("entity_type = ? AND entity_name = ?", entityUser, "alice").First(&tracked).Error; err != nil {
+		t.Fatalf("fetch tracking row: %v", err)
+	}
+	if tracked.FilePath == "" || tracked.FileHash == "" {
+		t.Fatalf("expected tracking metadata to be set")
+	}
+}

--- a/internal/service/configsync/config_sync_test.go
+++ b/internal/service/configsync/config_sync_test.go
@@ -8,7 +8,9 @@ import (
 
 	"github.com/mcpjungle/mcpjungle/internal/migrations"
 	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcp"
 	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
+	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
 	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"gorm.io/driver/sqlite"
@@ -25,6 +27,112 @@ func newTestDB(t *testing.T) *gorm.DB {
 		t.Fatalf("failed to migrate db: %v", err)
 	}
 	return db
+}
+
+func TestNew_DisabledSyncSkipsDependencyValidation(t *testing.T) {
+	s, err := New(Options{Enabled: false}, nil, Services{})
+	if err != nil {
+		t.Fatalf("expected disabled config sync constructor to succeed, got: %v", err)
+	}
+	if s == nil {
+		t.Fatal("expected non-nil service")
+	}
+}
+
+func TestNew_EnabledRequiresCoreDependencies(t *testing.T) {
+	db := newTestDB(t)
+
+	tests := []struct {
+		name     string
+		db       *gorm.DB
+		services Services
+	}{
+		{
+			name:     "missing db",
+			db:       nil,
+			services: Services{MCPService: &mcp.MCPService{}, ToolGroupService: &toolgroup.ToolGroupService{}},
+		},
+		{
+			name:     "missing mcp service",
+			db:       db,
+			services: Services{ToolGroupService: &toolgroup.ToolGroupService{}},
+		},
+		{
+			name:     "missing toolgroup service",
+			db:       db,
+			services: Services{MCPService: &mcp.MCPService{}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(Options{
+				Enabled: true,
+				Dir:     t.TempDir(),
+			}, tt.db, tt.services)
+			if err == nil {
+				t.Fatal("expected constructor error")
+			}
+			if !strings.Contains(err.Error(), "requires DB, MCP service and ToolGroup service") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestNew_EnabledRequiresDir(t *testing.T) {
+	db := newTestDB(t)
+	_, err := New(Options{
+		Enabled: true,
+		Dir:     "",
+	}, db, Services{
+		MCPService:       &mcp.MCPService{},
+		ToolGroupService: &toolgroup.ToolGroupService{},
+	})
+	if err == nil {
+		t.Fatal("expected constructor error")
+	}
+	if !strings.Contains(err.Error(), "requires a directory to watch") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_EnterpriseSyncRequiresUserAndMcpClientServices(t *testing.T) {
+	db := newTestDB(t)
+	_, err := New(Options{
+		Enabled:                    true,
+		Dir:                        t.TempDir(),
+		EnableEnterpriseEntitySync: true,
+	}, db, Services{
+		MCPService:       &mcp.MCPService{},
+		ToolGroupService: &toolgroup.ToolGroupService{},
+	})
+	if err == nil {
+		t.Fatal("expected constructor error")
+	}
+	if !strings.Contains(err.Error(), "requires User service and MCP Client service") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestNew_EnterpriseSyncWithAllDependenciesSucceeds(t *testing.T) {
+	db := newTestDB(t)
+	svc, err := New(Options{
+		Enabled:                    true,
+		Dir:                        t.TempDir(),
+		EnableEnterpriseEntitySync: true,
+	}, db, Services{
+		MCPService:       &mcp.MCPService{},
+		ToolGroupService: &toolgroup.ToolGroupService{},
+		UserService:      user.NewUserService(db),
+		MCPClientService: mcpclient.NewMCPClientService(db),
+	})
+	if err != nil {
+		t.Fatalf("expected constructor success, got: %v", err)
+	}
+	if svc == nil {
+		t.Fatal("expected non-nil service")
+	}
 }
 
 func TestReconcileUsers_AdminUserIsRejected(t *testing.T) {

--- a/internal/service/configsync/config_sync_test.go
+++ b/internal/service/configsync/config_sync_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mcpjungle/mcpjungle/internal/migrations"
 	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
 	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"gorm.io/driver/sqlite"
@@ -16,7 +17,7 @@ import (
 
 func newTestDB(t *testing.T) *gorm.DB {
 	t.Helper()
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open(filepath.Join(t.TempDir(), "configsync-test.db")), &gorm.Config{})
 	if err != nil {
 		t.Fatalf("failed to open db: %v", err)
 	}
@@ -30,7 +31,7 @@ func TestReconcileUsers_AdminUserIsRejected(t *testing.T) {
 	db := newTestDB(t)
 	userService := user.NewUserService(db)
 	tmp := t.TempDir()
-	s := &Service{db: db, services: Services{UserService: userService}, opts: Options{Dir: tmp}}
+	s := &Service{db: db, services: Services{UserService: userService}, opts: Options{Dir: tmp, EnableEnterpriseEntitySync: true}}
 
 	if err := s.ensureSubDirs(); err != nil {
 		t.Fatalf("ensure dirs: %v", err)
@@ -64,7 +65,7 @@ func TestReconcileUsers_AdoptsExistingManualUser(t *testing.T) {
 	db := newTestDB(t)
 	userService := user.NewUserService(db)
 	tmp := t.TempDir()
-	s := &Service{db: db, services: Services{UserService: userService}, opts: Options{Dir: tmp}}
+	s := &Service{db: db, services: Services{UserService: userService}, opts: Options{Dir: tmp, EnableEnterpriseEntitySync: true}}
 
 	if err := s.ensureSubDirs(); err != nil {
 		t.Fatalf("ensure dirs: %v", err)
@@ -95,5 +96,123 @@ func TestReconcileUsers_AdoptsExistingManualUser(t *testing.T) {
 	}
 	if tracked.FilePath == "" || tracked.FileHash == "" {
 		t.Fatalf("expected tracking metadata to be set")
+	}
+}
+
+func TestReconcileUsers_SkipsInDevelopmentMode(t *testing.T) {
+	db := newTestDB(t)
+	userService := user.NewUserService(db)
+	tmp := t.TempDir()
+	s := &Service{db: db, services: Services{UserService: userService}, opts: Options{Dir: tmp, EnableEnterpriseEntitySync: false}}
+
+	if err := s.ensureSubDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+
+	if err := db.Create(&model.User{Username: "alice", Role: types.UserRoleUser, AccessToken: "mcpjungle_test_oldtoken"}).Error; err != nil {
+		t.Fatalf("seed alice: %v", err)
+	}
+	if err := db.Create(&model.User{Username: "bob", Role: types.UserRoleUser, AccessToken: "mcpjungle_test_bob"}).Error; err != nil {
+		t.Fatalf("seed bob: %v", err)
+	}
+	if err := db.Create(&model.ManagedConfigFile{
+		EntityType: model.EntityTypeUser,
+		EntityName: "bob",
+		FilePath:   filepath.Join(tmp, "users", "bob.json"),
+		FileHash:   "oldhash",
+	}).Error; err != nil {
+		t.Fatalf("seed managed row: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tmp, "users", "alice.json"), []byte(`{"name":"alice","access_token":"mcpjungle_test_newtoken"}`), 0o644); err != nil {
+		t.Fatalf("write alice file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, "users", "carol.json"), []byte(`{"name":"carol","access_token":"mcpjungle_test_carol"}`), 0o644); err != nil {
+		t.Fatalf("write carol file: %v", err)
+	}
+
+	if err := s.reconcileUsers(); err != nil {
+		t.Fatalf("reconcile users in dev mode: %v", err)
+	}
+
+	var alice model.User
+	if err := db.Where("username = ?", "alice").First(&alice).Error; err != nil {
+		t.Fatalf("fetch alice: %v", err)
+	}
+	if alice.AccessToken != "mcpjungle_test_oldtoken" {
+		t.Fatalf("expected alice to remain unchanged in dev mode, got %s", alice.AccessToken)
+	}
+
+	var carol model.User
+	if err := db.Where("username = ?", "carol").First(&carol).Error; err == nil {
+		t.Fatal("expected carol to not be created in dev mode")
+	}
+
+	var bob model.User
+	if err := db.Where("username = ?", "bob").First(&bob).Error; err != nil {
+		t.Fatalf("expected bob to not be deleted in dev mode: %v", err)
+	}
+
+	var tracked model.ManagedConfigFile
+	if err := db.Where("entity_type = ? AND entity_name = ?", model.EntityTypeUser, "bob").First(&tracked).Error; err != nil {
+		t.Fatalf("expected managed tracking row for bob to remain: %v", err)
+	}
+}
+
+func TestReconcileMcpClients_SkipsInDevelopmentMode(t *testing.T) {
+	db := newTestDB(t)
+	clientService := mcpclient.NewMCPClientService(db)
+	tmp := t.TempDir()
+	s := &Service{db: db, services: Services{MCPClientService: clientService}, opts: Options{Dir: tmp, EnableEnterpriseEntitySync: false}}
+
+	if err := s.ensureSubDirs(); err != nil {
+		t.Fatalf("ensure dirs: %v", err)
+	}
+
+	if _, err := clientService.CreateClient(model.McpClient{
+		Name:        "alpha",
+		AccessToken: "mcpjungle_test_alpha_old",
+	}); err != nil {
+		t.Fatalf("seed alpha client: %v", err)
+	}
+	if _, err := clientService.CreateClient(model.McpClient{
+		Name:        "beta",
+		AccessToken: "mcpjungle_test_beta",
+	}); err != nil {
+		t.Fatalf("seed beta client: %v", err)
+	}
+	if err := db.Create(&model.ManagedConfigFile{
+		EntityType: model.EntityTypeMcpClient,
+		EntityName: "beta",
+		FilePath:   filepath.Join(tmp, types.ConfigSyncMcpClientsDirName, "beta.json"),
+		FileHash:   "oldhash",
+	}).Error; err != nil {
+		t.Fatalf("seed managed client row: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(tmp, types.ConfigSyncMcpClientsDirName, "alpha.json"), []byte(`{"name":"alpha","access_token":"mcpjungle_test_alpha_new","allowed_servers":[]}`), 0o644); err != nil {
+		t.Fatalf("write alpha file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(tmp, types.ConfigSyncMcpClientsDirName, "gamma.json"), []byte(`{"name":"gamma","access_token":"mcpjungle_test_gamma","allowed_servers":[]}`), 0o644); err != nil {
+		t.Fatalf("write gamma file: %v", err)
+	}
+
+	if err := s.reconcileMcpClients(); err != nil {
+		t.Fatalf("reconcile mcp clients in dev mode: %v", err)
+	}
+
+	alpha, err := clientService.GetClient("alpha")
+	if err != nil {
+		t.Fatalf("fetch alpha: %v", err)
+	}
+	if alpha.AccessToken != "mcpjungle_test_alpha_old" {
+		t.Fatalf("expected alpha to remain unchanged in dev mode, got %s", alpha.AccessToken)
+	}
+
+	if _, err := clientService.GetClient("gamma"); err == nil {
+		t.Fatal("expected gamma to not be created in dev mode")
+	}
+	if _, err := clientService.GetClient("beta"); err != nil {
+		t.Fatalf("expected beta to not be deleted in dev mode: %v", err)
 	}
 }

--- a/internal/service/configsync/config_sync_test.go
+++ b/internal/service/configsync/config_sync_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mcpjungle/mcpjungle/internal/migrations"
 	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -27,8 +28,11 @@ func newTestDB(t *testing.T) *gorm.DB {
 
 func TestReconcileUsers_AdminUserIsRejected(t *testing.T) {
 	db := newTestDB(t)
+	userService := user.NewUserService(db)
 	tmp := t.TempDir()
-	if err := ensureSubDirs(tmp); err != nil {
+	s := &Service{db: db, services: Services{UserService: userService}, opts: Options{Dir: tmp}}
+
+	if err := s.ensureSubDirs(); err != nil {
 		t.Fatalf("ensure dirs: %v", err)
 	}
 	if err := db.Create(&model.User{Username: "admin", Role: types.UserRoleAdmin, AccessToken: "mcpjungle_test_admin"}).Error; err != nil {
@@ -39,7 +43,6 @@ func TestReconcileUsers_AdminUserIsRejected(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	s := &Service{services: Services{DB: db}, opts: Options{Dir: tmp}}
 	err := s.reconcileUsers()
 	if err == nil {
 		t.Fatal("expected error")
@@ -59,8 +62,11 @@ func TestReconcileUsers_AdminUserIsRejected(t *testing.T) {
 
 func TestReconcileUsers_AdoptsExistingManualUser(t *testing.T) {
 	db := newTestDB(t)
+	userService := user.NewUserService(db)
 	tmp := t.TempDir()
-	if err := ensureSubDirs(tmp); err != nil {
+	s := &Service{db: db, services: Services{UserService: userService}, opts: Options{Dir: tmp}}
+
+	if err := s.ensureSubDirs(); err != nil {
 		t.Fatalf("ensure dirs: %v", err)
 	}
 	if err := db.Create(&model.User{Username: "alice", Role: types.UserRoleUser, AccessToken: "mcpjungle_test_oldtoken"}).Error; err != nil {
@@ -71,7 +77,6 @@ func TestReconcileUsers_AdoptsExistingManualUser(t *testing.T) {
 		t.Fatalf("write file: %v", err)
 	}
 
-	s := &Service{services: Services{DB: db}, opts: Options{Dir: tmp}}
 	if err := s.reconcileUsers(); err != nil {
 		t.Fatalf("reconcile users: %v", err)
 	}

--- a/internal/service/mcp/server.go
+++ b/internal/service/mcp/server.go
@@ -2,11 +2,15 @@ package mcp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log"
 
 	"github.com/mcpjungle/mcpjungle/internal/model"
+	"gorm.io/gorm"
 )
+
+var ErrMCPServerNotFound = errors.New("mcp server not found")
 
 // RegisterMcpServer registers a new MCP server in the database.
 // It also registers all the Tools and Prompts provided by the server.
@@ -89,6 +93,9 @@ func (m *MCPService) ListMcpServers() ([]model.McpServer, error) {
 func (m *MCPService) GetMcpServer(name string) (*model.McpServer, error) {
 	var serverModel model.McpServer
 	if err := m.db.Where("name = ?", name).First(&serverModel).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("%w: name=%s", ErrMCPServerNotFound, name)
+		}
 		return nil, err
 	}
 	return &serverModel, nil

--- a/internal/service/mcp/server_test.go
+++ b/internal/service/mcp/server_test.go
@@ -1,0 +1,35 @@
+package mcp
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/mark3labs/mcp-go/server"
+	"github.com/mcpjungle/mcpjungle/internal/telemetry"
+	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
+)
+
+func TestGetMcpServerNotFound(t *testing.T) {
+	setup := testhelpers.SetupMCPTest(t)
+	defer setup.Cleanup()
+
+	proxyServer := server.NewMCPServer("test-proxy", "0.1.0")
+	svc, err := NewMCPService(&ServiceConfig{
+		DB:                      setup.DB,
+		McpProxyServer:          proxyServer,
+		SseMcpProxyServer:       proxyServer,
+		Metrics:                 telemetry.NewNoopCustomMetrics(),
+		McpServerInitReqTimeout: 10,
+	})
+	if err != nil {
+		t.Fatalf("failed to create mcp service: %v", err)
+	}
+
+	_, err = svc.GetMcpServer("missing")
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, ErrMCPServerNotFound) {
+		t.Fatalf("expected ErrMCPServerNotFound, got: %v", err)
+	}
+}

--- a/internal/service/mcpclient/mcp_client.go
+++ b/internal/service/mcpclient/mcp_client.go
@@ -70,6 +70,19 @@ func (m *McpClientService) GetClientByToken(token string) (*model.McpClient, err
 	return &client, nil
 }
 
+// GetClient retrieves an MCP client by its name from the database.
+// It returns an error if no such client is found.
+func (m *McpClientService) GetClient(name string) (*model.McpClient, error) {
+	var client model.McpClient
+	if err := m.db.Where("name = ?", name).First(&client).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, errors.New("client not found")
+		}
+		return nil, err
+	}
+	return &client, nil
+}
+
 // DeleteClient removes an MCP client from the database and immediately revokes its access.
 // It is an idempotent operation. Deleting a client that does not exist will not return an error.
 func (m *McpClientService) DeleteClient(name string) error {

--- a/internal/service/mcpclient/mcp_client.go
+++ b/internal/service/mcpclient/mcp_client.go
@@ -10,6 +10,8 @@ import (
 	"gorm.io/gorm"
 )
 
+var ErrMCPClientNotFound = errors.New("mcp client not found")
+
 // McpClientService provides methods to manage MCP clients in the database.
 type McpClientService struct {
 	db *gorm.DB
@@ -63,7 +65,7 @@ func (m *McpClientService) GetClientByToken(token string) (*model.McpClient, err
 	var client model.McpClient
 	if err := m.db.Where("access_token = ?", token).First(&client).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, errors.New("client not found")
+			return nil, ErrMCPClientNotFound
 		}
 		return nil, err
 	}
@@ -76,7 +78,7 @@ func (m *McpClientService) GetClient(name string) (*model.McpClient, error) {
 	var client model.McpClient
 	if err := m.db.Where("name = ?", name).First(&client).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, errors.New("client not found")
+			return nil, fmt.Errorf("%w: name=%s", ErrMCPClientNotFound, name)
 		}
 		return nil, err
 	}
@@ -96,7 +98,7 @@ func (m *McpClientService) UpdateClient(updatedClient model.McpClient) (*model.M
 	var client model.McpClient
 	if err := m.db.Where("name = ?", updatedClient.Name).First(&client).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, errors.New("client not found")
+			return nil, fmt.Errorf("%w: name=%s", ErrMCPClientNotFound, updatedClient.Name)
 		}
 		return nil, err
 	}

--- a/internal/service/mcpclient/mcp_client_test.go
+++ b/internal/service/mcpclient/mcp_client_test.go
@@ -1,6 +1,7 @@
 package mcpclient
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/mcpjungle/mcpjungle/internal/model"
@@ -175,6 +176,9 @@ func TestGetClientByTokenNotFound(t *testing.T) {
 	// Try to get client with non-existent token
 	client, err := svc.GetClientByToken("non-existent-token")
 	testhelpers.AssertError(t, err)
+	if !errors.Is(err, ErrMCPClientNotFound) {
+		t.Fatalf("expected ErrMCPClientNotFound, got: %v", err)
+	}
 	if client != nil {
 		t.Error("Expected client to be nil when token not found")
 	}

--- a/internal/service/mcpclient/mcp_client_test.go
+++ b/internal/service/mcpclient/mcp_client_test.go
@@ -184,6 +184,48 @@ func TestGetClientByTokenNotFound(t *testing.T) {
 	}
 }
 
+func TestGetClient(t *testing.T) {
+	db, err := testhelpers.CreateTestDB()
+	testhelpers.AssertNoError(t, err)
+
+	err = db.AutoMigrate(&model.McpClient{})
+	testhelpers.AssertNoError(t, err)
+
+	svc := NewMCPClientService(db)
+
+	clientInput := model.McpClient{
+		Name:        "test-client",
+		Description: "Test MCP client",
+	}
+	created, err := svc.CreateClient(clientInput)
+	testhelpers.AssertNoError(t, err)
+
+	got, err := svc.GetClient("test-client")
+	testhelpers.AssertNoError(t, err)
+	testhelpers.AssertNotNil(t, got)
+	testhelpers.AssertEqual(t, created.Name, got.Name)
+	testhelpers.AssertEqual(t, created.AccessToken, got.AccessToken)
+}
+
+func TestGetClientNotFound(t *testing.T) {
+	db, err := testhelpers.CreateTestDB()
+	testhelpers.AssertNoError(t, err)
+
+	err = db.AutoMigrate(&model.McpClient{})
+	testhelpers.AssertNoError(t, err)
+
+	svc := NewMCPClientService(db)
+
+	got, err := svc.GetClient("missing-client")
+	testhelpers.AssertError(t, err)
+	if !errors.Is(err, ErrMCPClientNotFound) {
+		t.Fatalf("expected ErrMCPClientNotFound, got: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil client, got: %+v", got)
+	}
+}
+
 func TestDeleteClient(t *testing.T) {
 	db, err := testhelpers.CreateTestDB()
 	testhelpers.AssertNoError(t, err)

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -37,6 +37,19 @@ func (u *UserService) CreateAdminUser() (*model.User, error) {
 	return &user, nil
 }
 
+// GetUser retrieves a user by their username.
+// If a user with the specified username does not exist, an error is returned.
+func (u *UserService) GetUser(username string) (*model.User, error) {
+	var user model.User
+	if err := u.db.Where("username = ?", username).First(&user).Error; err != nil {
+		if errors.Is(err, gorm.ErrRecordNotFound) {
+			return nil, fmt.Errorf("user with username %s not found", username)
+		}
+		return nil, fmt.Errorf("failed to get user: %w", err)
+	}
+	return &user, nil
+}
+
 // GetUserByAccessToken returns a user associated with the provided access token.
 // If no user is found, an error is returned.
 func (u *UserService) GetUserByAccessToken(token string) (*model.User, error) {

--- a/internal/service/user/user.go
+++ b/internal/service/user/user.go
@@ -11,6 +11,8 @@ import (
 	"gorm.io/gorm"
 )
 
+var ErrUserNotFound = errors.New("user not found")
+
 // UserService provides methods to manage users in the MCPJungle system.
 type UserService struct {
 	db *gorm.DB
@@ -43,7 +45,7 @@ func (u *UserService) GetUser(username string) (*model.User, error) {
 	var user model.User
 	if err := u.db.Where("username = ?", username).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("user with username %s not found", username)
+			return nil, fmt.Errorf("%w: username=%s", ErrUserNotFound, username)
 		}
 		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
@@ -56,7 +58,7 @@ func (u *UserService) GetUserByAccessToken(token string) (*model.User, error) {
 	var user model.User
 	if err := u.db.Where("access_token = ?", token).First(&user).Error; err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("user not found")
+			return nil, ErrUserNotFound
 		}
 		return nil, fmt.Errorf("failed to verify token: %w", err)
 	}
@@ -97,7 +99,7 @@ func (u *UserService) UpdateUser(input *model.User) (*model.User, error) {
 	err := u.db.Where("username = ?", input.Username).First(&user).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return nil, fmt.Errorf("user with username %s not found", input.Username)
+			return nil, fmt.Errorf("%w: username=%s", ErrUserNotFound, input.Username)
 		}
 		return nil, fmt.Errorf("failed to find user: %w", err)
 	}
@@ -134,7 +136,7 @@ func (u *UserService) DeleteUser(username string) error {
 	err := u.db.Where("username = ?", username).First(&user).Error
 	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
-			return fmt.Errorf("user with username %s not found", username)
+			return fmt.Errorf("%w: username=%s", ErrUserNotFound, username)
 		}
 		return fmt.Errorf("failed to find user: %w", err)
 	}

--- a/internal/service/user/user_test.go
+++ b/internal/service/user/user_test.go
@@ -1,6 +1,7 @@
 package user
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/mcpjungle/mcpjungle/internal/model"
@@ -116,6 +117,9 @@ func TestGetUserByAccessToken(t *testing.T) {
 	// Test getting user by invalid token
 	_, err := svc.GetUserByAccessToken("invalid-token")
 	testhelpers.AssertError(t, err)
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("expected ErrUserNotFound, got: %v", err)
+	}
 }
 
 func TestListUsers(t *testing.T) {
@@ -178,6 +182,9 @@ func TestDeleteUserNotFound(t *testing.T) {
 	// Try to delete non-existent user
 	err := svc.DeleteUser("nonexistent")
 	testhelpers.AssertError(t, err)
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("expected ErrUserNotFound, got: %v", err)
+	}
 }
 
 func TestDeleteAdminUser(t *testing.T) {
@@ -251,6 +258,9 @@ func TestUpdateUserNotFound(t *testing.T) {
 	}
 	updatedUser, err := svc.UpdateUser(updateInput)
 	testhelpers.AssertError(t, err)
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("expected ErrUserNotFound, got: %v", err)
+	}
 	if updatedUser != nil {
 		t.Error("Expected update to fail for non-existent user")
 	}

--- a/internal/service/user/user_test.go
+++ b/internal/service/user/user_test.go
@@ -122,6 +122,36 @@ func TestGetUserByAccessToken(t *testing.T) {
 	}
 }
 
+func TestGetUser(t *testing.T) {
+	setup, _ := testhelpers.SetupUserTest(t)
+	defer setup.Cleanup()
+	svc := NewUserService(setup.DB)
+
+	created, err := svc.CreateUser(&model.User{Username: "alice"})
+	testhelpers.AssertNoError(t, err)
+
+	got, err := svc.GetUser("alice")
+	testhelpers.AssertNoError(t, err)
+	testhelpers.AssertNotNil(t, got)
+	testhelpers.AssertEqual(t, created.Username, got.Username)
+	testhelpers.AssertEqual(t, created.AccessToken, got.AccessToken)
+}
+
+func TestGetUserNotFound(t *testing.T) {
+	setup, _ := testhelpers.SetupUserTest(t)
+	defer setup.Cleanup()
+	svc := NewUserService(setup.DB)
+
+	got, err := svc.GetUser("missing-user")
+	testhelpers.AssertError(t, err)
+	if !errors.Is(err, ErrUserNotFound) {
+		t.Fatalf("expected ErrUserNotFound, got: %v", err)
+	}
+	if got != nil {
+		t.Errorf("expected nil user, got: %+v", got)
+	}
+}
+
 func TestListUsers(t *testing.T) {
 	setup := testhelpers.SetupTestDB(t)
 	defer setup.Cleanup()

--- a/pkg/accesstoken/access_token.go
+++ b/pkg/accesstoken/access_token.go
@@ -1,0 +1,53 @@
+package accesstoken
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/mcpjungle/mcpjungle/pkg/types"
+)
+
+// Input defines how to resolve an effective access token.
+type Input struct {
+	Inline string
+	Ref    types.AccessTokenRef
+}
+
+// Resolve returns the effective access token using the following precedence:
+// 1. Inline token if it is not empty
+// 2. Environment variable specified in Ref.Env
+// 3. File specified in Ref.File
+// If none are present, it returns an empty token and no error.
+func Resolve(input Input) (string, error) {
+	if input.Inline != "" {
+		return input.Inline, nil
+	}
+
+	if input.Ref.Env != "" {
+		value, ok := os.LookupEnv(input.Ref.Env)
+		if ok {
+			trimmed := strings.TrimSpace(value)
+			if trimmed != "" {
+				return trimmed, nil
+			}
+		}
+		if input.Ref.File == "" {
+			return "", fmt.Errorf("environment variable %s is not set or empty", input.Ref.Env)
+		}
+	}
+
+	if input.Ref.File != "" {
+		data, err := os.ReadFile(input.Ref.File)
+		if err != nil {
+			return "", fmt.Errorf("failed to read access token file %s: %w", input.Ref.File, err)
+		}
+		trimmed := strings.TrimSpace(string(data))
+		if trimmed == "" {
+			return "", fmt.Errorf("access token file %s is empty", input.Ref.File)
+		}
+		return trimmed, nil
+	}
+
+	return "", nil
+}

--- a/pkg/accesstoken/access_token_test.go
+++ b/pkg/accesstoken/access_token_test.go
@@ -1,0 +1,51 @@
+package accesstoken
+
+import (
+	"os"
+	"testing"
+
+	"github.com/mcpjungle/mcpjungle/pkg/types"
+)
+
+func TestResolve(t *testing.T) {
+	t.Run("inline token wins", func(t *testing.T) {
+		token, err := Resolve(Input{Inline: "direct-token"})
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if token != "direct-token" {
+			t.Fatalf("expected direct-token, got: %s", token)
+		}
+	})
+
+	t.Run("env token is used", func(t *testing.T) {
+		env := "MCPJ_TEST_TOKEN_ENV"
+		_ = os.Setenv(env, "  env-token  ")
+		defer os.Unsetenv(env)
+
+		token, err := Resolve(Input{Ref: types.AccessTokenRef{Env: env}})
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if token != "env-token" {
+			t.Fatalf("expected env-token, got: %s", token)
+		}
+	})
+
+	t.Run("file token is used", func(t *testing.T) {
+		f, err := os.CreateTemp("", "mcpj-token-*")
+		if err != nil {
+			t.Fatalf("create temp file: %v", err)
+		}
+		_ = os.WriteFile(f.Name(), []byte("  file-token\n"), 0o600)
+		defer os.Remove(f.Name())
+
+		token, err := Resolve(Input{Ref: types.AccessTokenRef{File: f.Name()}})
+		if err != nil {
+			t.Fatalf("expected no error, got: %v", err)
+		}
+		if token != "file-token" {
+			t.Fatalf("expected file-token, got: %s", token)
+		}
+	})
+}

--- a/pkg/accesstoken/doc.go
+++ b/pkg/accesstoken/doc.go
@@ -1,0 +1,9 @@
+// Package accesstoken provides shared logic to resolve effective access tokens
+// from config inputs that may define either:
+// - an inline access token,
+// - a reference to an environment variable,
+// - or a reference to a file.
+//
+// It centralizes resolution precedence and validation so CLI and services
+// behave consistently when processing access token configuration.
+package accesstoken

--- a/pkg/configfiles/configfiles.go
+++ b/pkg/configfiles/configfiles.go
@@ -1,0 +1,90 @@
+package configfiles
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// DesiredFile represents a config file on disk that should map to a desired entity in the system.
+type DesiredFile[T any] struct {
+	Entity T
+	Name   string
+	Path   string
+	Hash   string
+}
+
+// ReadJSONFile reads and unmarshals a JSON config file.
+func ReadJSONFile[T any](filePath string) (T, error) {
+	var input T
+
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return input, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+	}
+	if err := json.Unmarshal(data, &input); err != nil {
+		return input, fmt.Errorf("failed to parse config file: %w", err)
+	}
+
+	return input, nil
+}
+
+// LoadDesired reads JSON config files from dir and returns desired entities keyed by name.
+func LoadDesired[T any](dir string, nameFn func(T) string) (map[string]DesiredFile[T], map[string]bool, []error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, nil, []error{fmt.Errorf("failed to read directory %s: %w", dir, err)}
+	}
+
+	result := map[string]DesiredFile[T]{}
+	blocked := map[string]bool{}
+	var errs []error
+
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".json") {
+			continue
+		}
+		full := filepath.Join(dir, e.Name())
+		raw, err := os.ReadFile(full)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to read config file %s: %w", full, err))
+			blocked[full] = true
+			continue
+		}
+
+		var conf T
+		if err := json.Unmarshal(raw, &conf); err != nil {
+			errs = append(errs, fmt.Errorf("invalid JSON in %s: %w", full, err))
+			blocked[full] = true
+			continue
+		}
+
+		name := strings.TrimSpace(nameFn(conf))
+		if name == "" {
+			errs = append(errs, fmt.Errorf("config file %s does not define a valid name", full))
+			blocked[full] = true
+			continue
+		}
+
+		if existing, ok := result[name]; ok {
+			errs = append(errs, fmt.Errorf("conflict: duplicate %s defined by %s and %s", name, existing.Path, full))
+			blocked[full] = true
+			blocked[existing.Path] = true
+			continue
+		}
+
+		h := sha256.Sum256(raw)
+		result[name] = DesiredFile[T]{
+			Entity: conf,
+			Name:   name,
+			Path:   full,
+			Hash:   hex.EncodeToString(h[:]),
+		}
+	}
+
+	return result, blocked, errs
+}

--- a/pkg/configfiles/configfiles_test.go
+++ b/pkg/configfiles/configfiles_test.go
@@ -1,0 +1,89 @@
+package configfiles
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+type testConfig struct {
+	Name string `json:"name"`
+}
+
+func TestReadJSONFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entity.json")
+
+	if err := os.WriteFile(path, []byte(`{"name":"alpha"}`), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	got, err := ReadJSONFile[testConfig](path)
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if got.Name != "alpha" {
+		t.Fatalf("expected name alpha, got %s", got.Name)
+	}
+}
+
+func TestReadJSONFile_InvalidJSON(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "entity.json")
+
+	if err := os.WriteFile(path, []byte(`{"name":`), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	_, err := ReadJSONFile[testConfig](path)
+	if err == nil {
+		t.Fatal("expected error for invalid JSON, got nil")
+	}
+}
+
+func TestLoadDesired(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "a.json"), []byte(`{"name":"a"}`), 0o644); err != nil {
+		t.Fatalf("write file a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.json"), []byte(`{"name":"b"}`), 0o644); err != nil {
+		t.Fatalf("write file b: %v", err)
+	}
+
+	desired, blocked, errs := LoadDesired[testConfig](dir, func(c testConfig) string { return c.Name })
+	if len(errs) != 0 {
+		t.Fatalf("expected no parse errors, got: %v", errs)
+	}
+	if len(blocked) != 0 {
+		t.Fatalf("expected no blocked files, got: %v", blocked)
+	}
+	if len(desired) != 2 {
+		t.Fatalf("expected 2 desired entries, got %d", len(desired))
+	}
+	if desired["a"].Name != "a" || desired["a"].Path == "" || desired["a"].Hash == "" {
+		t.Fatalf("expected metadata for a to be populated, got: %+v", desired["a"])
+	}
+}
+
+func TestLoadDesired_DuplicateName(t *testing.T) {
+	dir := t.TempDir()
+
+	if err := os.WriteFile(filepath.Join(dir, "a.json"), []byte(`{"name":"dupe"}`), 0o644); err != nil {
+		t.Fatalf("write file a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.json"), []byte(`{"name":"dupe"}`), 0o644); err != nil {
+		t.Fatalf("write file b: %v", err)
+	}
+
+	desired, blocked, errs := LoadDesired[testConfig](dir, func(c testConfig) string { return c.Name })
+	if len(errs) == 0 {
+		t.Fatal("expected duplicate-name error, got none")
+	}
+	if len(desired) != 1 {
+		t.Fatalf("expected 1 desired entry after duplicate conflict, got %d", len(desired))
+	}
+	if len(blocked) != 2 {
+		t.Fatalf("expected 2 blocked files for duplicate conflict, got %d", len(blocked))
+	}
+}

--- a/pkg/configfiles/doc.go
+++ b/pkg/configfiles/doc.go
@@ -1,0 +1,10 @@
+// Package configfiles provides shared helpers to load and parse JSON entity
+// configuration files used by both CLI commands and config sync reconciliation.
+//
+// It centralizes common concerns such as:
+// - reading and unmarshaling JSON config files,
+// - loading desired state from config directories,
+// - validating entity names for desired entries,
+// - computing content hashes for change detection,
+// - and reporting duplicate/blocked config files consistently.
+package configfiles

--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -1,11 +1,5 @@
 package types
 
-import (
-	"fmt"
-	"os"
-	"strings"
-)
-
 // AccessTokenRef describes how to load a secret access token from an external source.
 type AccessTokenRef struct {
 	// Env indicates that the access token should be loaded from an environment variable.
@@ -15,43 +9,4 @@ type AccessTokenRef struct {
 	// File indicates that the access token should be loaded from a file.
 	// The value is the path to the file.
 	File string `json:"file"`
-}
-
-// ResolveAccessToken returns the effective access token.
-// Precedence:
-// 1. Primary token if it is not empty
-// 2. Environment variable specified in .Env
-// 3. File specified in .File
-// If none are present, this method returns an empty string.
-func (r *AccessTokenRef) ResolveAccessToken(primaryToken string) (string, error) {
-	if primaryToken != "" {
-		return primaryToken, nil
-	}
-
-	if r.Env != "" {
-		value, ok := os.LookupEnv(r.Env)
-		if ok {
-			trimmed := strings.TrimSpace(value)
-			if trimmed != "" {
-				return trimmed, nil
-			}
-		}
-		if r.File == "" {
-			return "", fmt.Errorf("environment variable %s is not set or empty", r.Env)
-		}
-	}
-
-	if r.File != "" {
-		data, err := os.ReadFile(r.File)
-		if err != nil {
-			return "", fmt.Errorf("failed to read access token file %s: %w", r.File, err)
-		}
-		trimmed := strings.TrimSpace(string(data))
-		if trimmed == "" {
-			return "", fmt.Errorf("access token file %s is empty", r.File)
-		}
-		return trimmed, nil
-	}
-
-	return "", nil
 }

--- a/pkg/types/common.go
+++ b/pkg/types/common.go
@@ -1,0 +1,57 @@
+package types
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// AccessTokenRef describes how to load a secret access token from an external source.
+type AccessTokenRef struct {
+	// Env indicates that the access token should be loaded from an environment variable.
+	// The value is the name of the environment variable.
+	Env string `json:"env"`
+
+	// File indicates that the access token should be loaded from a file.
+	// The value is the path to the file.
+	File string `json:"file"`
+}
+
+// ResolveAccessToken returns the effective access token.
+// Precedence:
+// 1. Primary token if it is not empty
+// 2. Environment variable specified in .Env
+// 3. File specified in .File
+// If none are present, this method returns an empty string.
+func (r *AccessTokenRef) ResolveAccessToken(primaryToken string) (string, error) {
+	if primaryToken != "" {
+		return primaryToken, nil
+	}
+
+	if r.Env != "" {
+		value, ok := os.LookupEnv(r.Env)
+		if ok {
+			trimmed := strings.TrimSpace(value)
+			if trimmed != "" {
+				return trimmed, nil
+			}
+		}
+		if r.File == "" {
+			return "", fmt.Errorf("environment variable %s is not set or empty", r.Env)
+		}
+	}
+
+	if r.File != "" {
+		data, err := os.ReadFile(r.File)
+		if err != nil {
+			return "", fmt.Errorf("failed to read access token file %s: %w", r.File, err)
+		}
+		trimmed := strings.TrimSpace(string(data))
+		if trimmed == "" {
+			return "", fmt.Errorf("access token file %s is empty", r.File)
+		}
+		return trimmed, nil
+	}
+
+	return "", nil
+}

--- a/pkg/types/config_dir_sync.go
+++ b/pkg/types/config_dir_sync.go
@@ -1,0 +1,12 @@
+package types
+
+// DefaultConfigSyncDirName is the default name of the directory containing entity configuration files for
+// syncing with mcpjungle.
+const DefaultConfigSyncDirName = ".mcpjungle"
+
+const (
+	ConfigSyncMcpServersDirName = "mcp_servers"
+	ConfigSyncMcpClientsDirName = "mcp_clients"
+	ConfigSyncUsersDirName      = "users"
+	ConfigSyncGroupsDirName     = "groups"
+)

--- a/pkg/types/mcp_client.go
+++ b/pkg/types/mcp_client.go
@@ -14,17 +14,6 @@ type McpClient struct {
 	AllowList []string `json:"allow_list"`
 }
 
-// AccessTokenRef describes how to load a secret access token from an external source.
-type AccessTokenRef struct {
-	// Env indicates that the access token should be loaded from an environment variable.
-	// The value is the name of the environment variable.
-	Env string `json:"env"`
-
-	// File indicates that the access token should be loaded from a file.
-	// The value is the path to the file.
-	File string `json:"file"`
-}
-
 // McpClientConfig describes the JSON configuration for creating an MCP client.
 type McpClientConfig struct {
 	// Name is the unique name of the MCP client (mandatory)


### PR DESCRIPTION
### Motivation

- Ensure the config-sync feature uses an absolute, well-formed default directory instead of returning a raw `~/.mcpjungle` string so downstream code and consumers get a concrete path. 
- Wire up the config-sync feature end-to-end so the server can optionally manage desired-state entities from a directory, track them, and keep them live-synced. 
- Provide safe guardrails for adoption of manual entities, admin user protection, and preserving last-good state on parse/validation errors. 

### Description

- Add `DefaultConfigSyncDirName` constant and change `getConfigSyncDir()` to resolve the current user home via `os.UserHomeDir()` and return `filepath.Join(home, DefaultConfigSyncDirName)` with a fallback to `filepath.Join("~", DefaultConfigSyncDirName)` when home resolution fails. 
- Add CLI flags `--config-sync` and `--config-dir` and env var support (`MCPJUNGLE_CONFIG_SYNC_ENABLED`, `MCPJUNGLE_CONFIG_DIR`), and wire a new `configsync` service into startup so it is initialized and started when enabled. 
- Introduce a `ManagedConfigFile` model and include it in migrations, and implement a full `configsync` service that resolves the config dir, ensures subdirectories, watches with `fsnotify`, and reconciles `mcp_servers`, `mcp_clients`, `groups`, and `users` with adoption, tracking, and error aggregation behavior. 
- Update `README.md` to document the auto-synced config directory feature, layout, behavior, and guardrails, and add/update unit tests for CLI helpers and config-sync behaviors. 

### Testing

- Ran the focused cmd unit test `go test -vet=off ./cmd -run '^TestGetConfigSyncDir$' -count=1`, which passed. 
- Ran `gofmt` on modified files and committed the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c84c16be48332869097de3f4e31fd)