### PR TITLE
docs: add custom registry URL configuration section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ MCPJungle is an open source, self-hosted Gateway for all your [Model Context Pro
     - [Adding Streamable HTTP-based MCP servers](#registering-streamable-http-based-servers)
     - [Adding STDIO-based MCP servers](#registering-stdio-based-servers)
     - [Removing MCP servers](#deregistering-mcp-servers)
+    - [Custom URL for server](#configuring-a-custom-registry-url)
   - [Cold-start problem & Stateful Connections](#cold-start-problem--stateful-connections)
   - [Connect to mcpjungle from Claude](#claude)
   - [Connect to mcpjungle from Cursor](#cursor)
@@ -254,27 +255,6 @@ mcpjungle start
 ## Client
 Once the server is up, you can use the mcpjungle CLI to interact with it.
 
-### Configuring a custom registry URL
-
-By default, the CLI connects to `http://127.0.0.1:8000`. If your MCPJungle server is running on a different host or port (e.g., a remote deployment), you can configure the registry URL in two ways:
-
-**Option 1: Use the `--registry` flag**
-```bash
-mcpjungle list tools --registry http://my-server:8080
-```
-
-**Option 2: Set it in the config file**
-
-Create or edit `~/.mcpjungle.conf`:
-```yaml
-registry_url: http://my-server:8080
-```
-
-This avoids having to pass the `--registry` flag on every command.
-
-> [!TIP]
-> The CLI will automatically suggest saving the registry URL to `~/.mcpjungle.conf` when you use the `--registry` flag for the first time.
-
 MCPJungle currently supports MCP servers using [stdio](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#stdio) and [Streamable HTTP](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) Transports.
 
 > [!NOTE]
@@ -426,6 +406,27 @@ mcpjungle deregister filesystem
 ```
 
 Once removed, this mcp server and its tools are no longer available to you or your MCP clients.
+
+### Configuring a custom registry URL
+
+By default, the CLI connects to the mcpjungle server at `http://127.0.0.1:8000`.
+
+If your server is running on a different host or port (e.g., a remote deployment), you can configure the registry URL in two ways:
+
+**Option 1: Use the `--registry` flag**
+```bash
+mcpjungle --registry http://my-server:9000 list tools
+```
+
+**Option 2: Set it in the config file**
+
+Create or edit `~/.mcpjungle.conf`:
+```yaml
+registry_url: http://my-server:9000
+```
+
+This avoids having to pass the `--registry` flag on every command.
+
 
 ## Cold-start problem & Stateful Connections
 By default, MCPJungle always creates a new connection with the upstream MCP server when a tool is called.


### PR DESCRIPTION
## Summary

Adds a new "Configuring a custom registry URL" section to the Client docs in the README, explaining how to:

1. Use the `--registry` flag for one-off commands
2. Set `registry_url` in `~/.mcpjungle.conf` for persistent configuration

This addresses the confusion reported in #184 where users deploying MCPJungle remotely are unsure how to point the CLI at their server.

Closes #184