### PR TITLE
feat(export-users-clients): add support for exporting users and clients

### DIFF
--- a/client/mcp_clients.go
+++ b/client/mcp_clients.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 )
@@ -88,6 +89,31 @@ func (c *Client) CreateMcpClient(mcpClient *types.McpClient) (string, error) {
 	}
 
 	return response.AccessToken, nil
+}
+
+// GetMcpClientConfigs returns the configurations of all registered MCP clients.
+// The returned configs can be used to recreate the clients elsewhere.
+// Access tokens are always included since the list endpoint returns them for all clients.
+func (c *Client) GetMcpClientConfigs() ([]types.McpClientConfig, error) {
+	clients, err := c.ListMcpClients()
+	if err != nil {
+		return nil, err
+	}
+
+	configs := make([]types.McpClientConfig, 0, len(clients))
+	for _, cl := range clients {
+		// Populate access_token_ref with a hint so the operator knows to supply the
+		// token via environment variable before reimporting.
+		envVarHint := "MCPJUNGLE_CLIENT_TOKEN_" + strings.ToUpper(strings.ReplaceAll(cl.Name, "-", "_"))
+		cfg := types.McpClientConfig{
+			Name:            cl.Name,
+			Description:     cl.Description,
+			AllowMcpServers: cl.AllowList,
+			AccessTokenRef:  types.AccessTokenRef{Env: envVarHint},
+		}
+		configs = append(configs, cfg)
+	}
+	return configs, nil
 }
 
 func (c *Client) UpdateMcpClient(mcpClient *types.McpClient) error {

--- a/client/user.go
+++ b/client/user.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 )
@@ -118,6 +119,28 @@ func (c *Client) ListUsers() ([]*types.User, error) {
 		return nil, fmt.Errorf("failed to decode response: %w", err)
 	}
 	return users, nil
+}
+
+// GetUserConfigs returns the configurations of all users.
+// The returned configs can be used to recreate the users elsewhere.
+// Access tokens are not included as the list endpoint does not return them.
+func (c *Client) GetUserConfigs() ([]types.UserConfig, error) {
+	users, err := c.ListUsers()
+	if err != nil {
+		return nil, err
+	}
+
+	configs := make([]types.UserConfig, 0, len(users))
+	for _, u := range users {
+		// Populate access_token_ref with a hint so the operator knows to supply the
+		// token via environment variable before reimporting.
+		envVarHint := "MCPJUNGLE_USER_TOKEN_" + strings.ToUpper(strings.ReplaceAll(u.Username, "-", "_"))
+		configs = append(configs, types.UserConfig{
+			Username:       u.Username,
+			AccessTokenRef: types.AccessTokenRef{Env: envVarHint},
+		})
+	}
+	return configs, nil
 }
 
 // Whoami sends a request to get information about the user associated with the provided access token

--- a/cmd/export.go
+++ b/cmd/export.go
@@ -15,12 +15,14 @@ const defaultExportTargetDir = ".mcpjungle"
 const (
 	exportMcpServersDir = "servers"
 	exportToolGroupsDir = "groups"
+	exportMcpClientsDir = "clients"
+	exportUsersDir      = "users"
 )
 
 var exportCmd = &cobra.Command{
 	Use:   "export",
 	Short: "Export configuration files of all entities",
-	Long: "This command creates configuration files for all entities (mcp servers, groups) that exist in mcpjungle.\n" +
+	Long: "This command creates configuration files for all entities (mcp servers, groups, and in enterprise mode: mcp clients and users) that exist in mcpjungle.\n" +
 		"This is useful when you want to track all the entities registered in mcpjungle as code.\n" +
 		fmt.Sprintf("By default, the configurations are exported to a directory named %s in the current working directory.\n\n", defaultExportTargetDir) +
 		"NOTE: In enterprise mode, you must be an admin to export all configurations successfully.",
@@ -119,6 +121,14 @@ func runExport(cmd *cobra.Command, args []string) error {
 	if err := os.Mkdir(serversDir, 0o755); err != nil {
 		return fmt.Errorf("failed to create mcp servers directory: %w", err)
 	}
+	clientsDir := filepath.Join(targetDir, exportMcpClientsDir)
+	if err := os.Mkdir(clientsDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create mcp clients directory: %w", err)
+	}
+	usersDir := filepath.Join(targetDir, exportUsersDir)
+	if err := os.Mkdir(usersDir, 0o755); err != nil {
+		return fmt.Errorf("failed to create users directory: %w", err)
+	}
 
 	cmd.Println("Fetching Tool Group configurations...")
 
@@ -152,6 +162,48 @@ func runExport(cmd *cobra.Command, args []string) error {
 
 			for _, s := range servers {
 				if err := writeJSONConfigFile(serversDir, s.Name, s); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	cmd.Println("Fetching MCP Client configurations (enterprise mode only)...")
+
+	clientConfigs, cErr := apiClient.GetMcpClientConfigs()
+	if cErr != nil {
+		cmd.Printf("warning: failed to fetch mcp client configurations: %v\n", cErr)
+	} else {
+		if len(clientConfigs) == 0 {
+			cmd.Println("No MCP Clients found.")
+		} else {
+			cmd.Printf("Writing MCP Client configurations to %s\n", clientsDir)
+
+			for _, c := range clientConfigs {
+				if err := writeJSONConfigFile(clientsDir, c.Name, c); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	cmd.Println("Fetching User configurations (enterprise mode only)...")
+
+	userConfigs, uErr := apiClient.GetUserConfigs()
+	if uErr != nil {
+		cmd.Printf("warning: failed to fetch user configurations: %v\n", uErr)
+	} else {
+		if len(userConfigs) == 0 {
+			cmd.Println("No Users found.")
+		} else {
+			cmd.Printf("Writing User configurations to %s\n", usersDir)
+
+			for _, u := range userConfigs {
+				// skip admin — it is always created automatically by init-server
+				if u.Username == "admin" {
+					continue
+				}
+				if err := writeJSONConfigFile(usersDir, u.Username, u); err != nil {
 					return err
 				}
 			}

--- a/pkg/types/mcp_client.go
+++ b/pkg/types/mcp_client.go
@@ -18,11 +18,11 @@ type McpClient struct {
 type AccessTokenRef struct {
 	// Env indicates that the access token should be loaded from an environment variable.
 	// The value is the name of the environment variable.
-	Env string `json:"env"`
+	Env string `json:"env,omitempty"`
 
 	// File indicates that the access token should be loaded from a file.
 	// The value is the path to the file.
-	File string `json:"file"`
+	File string `json:"file,omitempty"`
 }
 
 // McpClientConfig describes the JSON configuration for creating an MCP client.

--- a/pkg/types/user.go
+++ b/pkg/types/user.go
@@ -19,7 +19,7 @@ type UserConfig struct {
 	// a hard-coded access token can be a security risk.
 	// Instead, use the AccessTokenRef field to load the access token from
 	// a secure location.
-	AccessToken string `json:"access_token"`
+	AccessToken string `json:"access_token,omitempty"`
 
 	// AccessTokenRef allows you to specify how to load the access token from
 	// an external source. Use this in production scenarios, especially when


### PR DESCRIPTION
- Add support for export users and client. 
- Verify using exported data in create command

```
# Users
./mcpjungle create user -c .mcpjungle/users/alice.json

# MCP Clients
./mcpjungle create mcp-client -c .mcpjungle/clients/my-ai-app.json
```