### PR TITLE
Clarify stdio stderr shutdown logging

### DIFF
--- a/internal/service/mcp/util.go
+++ b/internal/service/mcp/util.go
@@ -233,8 +233,10 @@ func captureStdioServerStderr(name string, c *client.Client) {
 		for {
 			n, err := stdioTransport.Stderr().Read(buf)
 			if err != nil {
-				if err == io.EOF || errors.Is(err, os.ErrClosed) {
+				if err == io.EOF {
 					log.Printf("['%s' MCP Server] [DEBUG] server process has exited gracefully", name)
+				} else if errors.Is(err, os.ErrClosed) {
+					log.Printf("['%s' MCP Server] [DEBUG] stderr pipe closed during client shutdown", name)
 				} else {
 					log.Printf("['%s' MCP STDERR] Error reading stderr: %v", name, err)
 				}

--- a/internal/service/mcp/util_test.go
+++ b/internal/service/mcp/util_test.go
@@ -4,11 +4,16 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log"
+	"os"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/mark3labs/mcp-go/client"
+	"github.com/mark3labs/mcp-go/client/transport"
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mcpjungle/mcpjungle/internal/model"
 )
@@ -284,4 +289,69 @@ func TestPrepareSHTTPClientOptions_BearerWithCustomAuthorization(t *testing.T) {
 	if !strings.Contains(logOutput, "custom Authorization header will be used for MCP server my-server; bearer_token ignored") {
 		t.Fatalf("expected log to mention bearer_token ignored when custom Authorization header present, got: %q", logOutput)
 	}
+}
+
+func waitForLogMessage(t *testing.T, buf *bytes.Buffer, want string) {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if strings.Contains(buf.String(), want) {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	t.Fatalf("expected log to contain %q, got %q", want, buf.String())
+}
+
+func newTestStdioClient(t *testing.T) (*client.Client, *os.File, *os.File) {
+	t.Helper()
+
+	stdoutReader, stdoutWriter := io.Pipe()
+	stdinReader, stdinWriter := io.Pipe()
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create stderr pipe: %v", err)
+	}
+
+	t.Cleanup(func() {
+		_ = stdoutReader.Close()
+		_ = stdoutWriter.Close()
+		_ = stdinReader.Close()
+		_ = stdinWriter.Close()
+		_ = stderrReader.Close()
+		_ = stderrWriter.Close()
+	})
+
+	stdio := transport.NewIO(stdoutReader, stdinWriter, stderrReader)
+	return client.NewClient(stdio), stderrReader, stderrWriter
+}
+
+func TestCaptureStdioServerStderr_LogsGracefulExitOnEOF(t *testing.T) {
+	c, _, stderrWriter := newTestStdioClient(t)
+
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	captureStdioServerStderr("demo", c)
+	_ = stderrWriter.Close()
+
+	waitForLogMessage(t, &buf, "['demo' MCP Server] [DEBUG] server process has exited gracefully")
+}
+
+func TestCaptureStdioServerStderr_LogsClientShutdownOnClosedPipe(t *testing.T) {
+	c, stderrReader, _ := newTestStdioClient(t)
+
+	var buf bytes.Buffer
+	old := log.Writer()
+	log.SetOutput(&buf)
+	defer log.SetOutput(old)
+
+	captureStdioServerStderr("demo", c)
+	_ = stderrReader.Close()
+
+	waitForLogMessage(t, &buf, "['demo' MCP Server] [DEBUG] stderr pipe closed during client shutdown")
 }


### PR DESCRIPTION
## Summary
- keep the existing graceful-exit log only for a real `io.EOF`
- log a separate message when the client closes the stderr pipe during shutdown
- add regression coverage for both shutdown paths

## Why
When debugging stdio child lifecycle issues, `os.ErrClosed` currently logs as `server process has exited gracefully`, which makes normal client cleanup look like a clean child exit. Distinguishing the two paths made it much easier to isolate the real shutdown hang in the paired `mcp-go` fix.

## Testing
- `go test ./internal/service/mcp`

Fixes #207
