### PR TITLE
fix: increase default MCP server init timeout to 30s and surface env var in errors

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -53,7 +53,7 @@ const (
 	McpServerInitReqTimeoutSecEnvVar = "MCP_SERVER_INIT_REQ_TIMEOUT_SEC"
 
 	// McpServerInitRequestTimeoutSecondsDefault is the default timeout in seconds for MCP server initialization requests.
-	McpServerInitRequestTimeoutSecondsDefault = 10
+	McpServerInitRequestTimeoutSecondsDefault = 30
 
 	// SessionIdleTimeoutSecEnvVar is the environment variable for configuring the idle timeout for stateful sessions.
 	SessionIdleTimeoutSecEnvVar = "SESSION_IDLE_TIMEOUT_SEC"
@@ -80,7 +80,7 @@ var startServerCmd = &cobra.Command{
 		"For Postgres, you can also set individual connection details using the following environment variables:\n" +
 		"POSTGRES_HOST, POSTGRES_PORT (default 5432), POSTGRES_USER (default postgres), POSTGRES_PASSWORD, POSTGRES_DB (default postgres)\n\n" +
 		"You can also configure the amount of time (in seconds) mcpjungle will wait for a new MCP server's initialization before aborting it.\n" +
-		"Set the MCP_SERVER_INIT_REQ_TIMEOUT_SEC environment variable to an integer (default is 10).\n" +
+		"Set the MCP_SERVER_INIT_REQ_TIMEOUT_SEC environment variable to an integer (default is 30).\n" +
 		"This is useful when you register a MCP server (usually stdio, like filesystem) that may take some time to start up.\n\n" +
 		"Finally, you can also configure the idle timeout (in seconds) for stateful sessions.\n" +
 		"Set the SESSION_IDLE_TIMEOUT_SEC environment variable to an integer (default is -1, meaning no timeout).\n" +

--- a/internal/service/mcp/util.go
+++ b/internal/service/mcp/util.go
@@ -207,7 +207,11 @@ func createHTTPMcpServerConn(ctx context.Context, s *model.McpServer, initReqTim
 	_, err = c.Initialize(initCtx, initRequest)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, fmt.Errorf("initialization request to MCP server timed out after %d seconds", initReqTimeoutSec)
+			return nil, fmt.Errorf(
+				"initialization request to MCP server timed out after %d seconds."+
+					" Set the MCP_SERVER_INIT_REQ_TIMEOUT_SEC environment variable to increase this timeout",
+				initReqTimeoutSec,
+			)
 		}
 		if errors.Is(err, syscall.ECONNREFUSED) && isLoopbackURL(conf.URL) {
 			return nil, fmt.Errorf(
@@ -290,7 +294,8 @@ func runStdioServer(ctx context.Context, s *model.McpServer, initReqTimeoutSec i
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, fmt.Errorf(
 				"initialization request to MCP server timed out after %d seconds,"+
-					" check mcpjungle server logs for any errors from this MCP server",
+					" check mcpjungle server logs for any errors from this MCP server."+
+					" Set the MCP_SERVER_INIT_REQ_TIMEOUT_SEC environment variable to increase this timeout",
 				initReqTimeoutSec,
 			)
 		}

--- a/internal/service/mcp/util.go
+++ b/internal/service/mcp/util.go
@@ -209,7 +209,7 @@ func createHTTPMcpServerConn(ctx context.Context, s *model.McpServer, initReqTim
 		if errors.Is(err, context.DeadlineExceeded) {
 			return nil, fmt.Errorf(
 				"initialization request to MCP server timed out after %d seconds."+
-					" Set the MCP_SERVER_INIT_REQ_TIMEOUT_SEC environment variable to increase this timeout",
+					" To increase the timeout, use the MCP_SERVER_INIT_REQ_TIMEOUT_SEC environment variable for the mcpjungle server",
 				initReqTimeoutSec,
 			)
 		}
@@ -295,7 +295,7 @@ func runStdioServer(ctx context.Context, s *model.McpServer, initReqTimeoutSec i
 			return nil, fmt.Errorf(
 				"initialization request to MCP server timed out after %d seconds,"+
 					" check mcpjungle server logs for any errors from this MCP server."+
-					" Set the MCP_SERVER_INIT_REQ_TIMEOUT_SEC environment variable to increase this timeout",
+					" To increase the timeout, use the MCP_SERVER_INIT_REQ_TIMEOUT_SEC environment variable for the mcpjungle server",
 				initReqTimeoutSec,
 			)
 		}


### PR DESCRIPTION
## Summary

Bumps the default MCP server initialization timeout from 10 to 30 seconds and tells users about the `MCP_SERVER_INIT_REQ_TIMEOUT_SEC` env var when a timeout occurs.

## Why this matters

10 seconds is too tight for Docker environments where stdio servers need to download dependencies before starting. Users hit the timeout with no guidance on how to fix it. The error messages now point them to the env var directly.

## Changes

- `cmd/start.go`: Changed `McpServerInitRequestTimeoutSecondsDefault` from `10` to `30`. Updated the help text to reflect the new default.
- `internal/service/mcp/util.go`: Added `MCP_SERVER_INIT_REQ_TIMEOUT_SEC` env var hint to both the HTTP connection timeout error (line 210) and the stdio connection timeout error (line 294).

Test fixtures use hardcoded values independent of the default constant, so they remain unchanged.

Fixes #156

This contribution was developed with AI assistance (Claude Code).