### PR TITLE
Add GitHub pull request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+## Summary
+
+<!-- Briefly explain what this PR changes and why. -->
+
+## Pre-Agreement Checklist (required)
+
+Please check all boxes before requesting review:
+
+- [ ] I have read and followed the [contribution guidelines](https://github.com/mcpjungle/MCPJungle/blob/main/CONTRIBUTION.md).
+- [ ] This PR addresses an existing issue or a concluded discussion.
+- [ ] If there was no existing issue/discussion, I opened one first to align with maintainers before submitting this PR.
+- [ ] I confirmed the issue/discussion priority with maintainers and understand low-priority items may receive limited attention.
+- [ ] I kept this PR focused and reasonably small; if the work is large, I split it into smaller PRs where possible.
+- [ ] Any AI-generated code in this PR was reviewed by a human author.
+
+## Validation Checklist
+
+- [ ] `go test ./...` passes locally.
+- [ ] `scripts/test-mcpjungle.sh` passes locally.
+- [ ] I added or updated tests for new behavior where applicable.
+- [ ] I updated documentation for user-facing changes where applicable.
+
+## Linked Context
+
+- Issue(s): <!-- e.g., #123 -->
+- Discussion(s): <!-- e.g., https://github.com/mcpjungle/MCPJungle/discussions/456 -->


### PR DESCRIPTION
### Motivation
- Introduce a repository-level pull request template to standardize PR descriptions and require contributors to follow a common checklist before requesting review.

### Description
- Add `.github/pull_request_template.md` which includes a `Summary` prompt, a `Pre-Agreement Checklist`, a `Validation Checklist` with `go test ./...` and `scripts/test-mcpjungle.sh` reminders, and `Linked Context` placeholders for issues and discussions.

### Testing
- No automated tests were run for this change because it only adds a documentation/template file and does not modify executable code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dca97783a08332a9c691bab10b7173)