### PR TITLE
feat(cli): better error message when get prompt is missing args

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -128,7 +128,7 @@ func runGetPrompt(cmd *cobra.Command, args []string) error {
 
 	result, err := apiClient.GetPromptWithArgs(name, arguments)
 	if err != nil {
-		return fmt.Errorf("failed to get prompt: %w", err)
+		return prettifyGetPromptError(name, err)
 	}
 
 	// Pretty print the result
@@ -153,4 +153,33 @@ func runGetPrompt(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+
+// prettifyGetPromptError rewrites low-level errors from GetPromptWithArgs into
+// something a CLI user can act on. It:
+//  1. Drops the redundant outer "failed to get prompt:" wrapping that
+//     duplicates the server's message.
+//  2. Adds a usage hint when the upstream MCP server reports invalid
+//     arguments (MCP JSON-RPC error -32602), because the raw error payload
+//     is a JSON array that looks like noise to someone running the command.
+func prettifyGetPromptError(name string, err error) error {
+	msg := err.Error()
+	// Strip any stacked "failed to get prompt: " prefixes the wrappers add.
+	const prefix = "failed to get prompt: "
+	for strings.HasPrefix(msg, prefix) {
+		msg = msg[len(prefix):]
+	}
+
+	// Detect the "Invalid arguments for prompt" shape from the MCP protocol
+	// (error -32602) and point the user at --arg so they can retry.
+	if strings.Contains(msg, "-32602") || strings.Contains(msg, "Invalid arguments for prompt") {
+		return fmt.Errorf(
+			"%s\n\nHint: prompt %q rejected the arguments you supplied. "+
+				"Pass required arguments with --arg key=value, e.g. "+
+				"`mcpjungle get prompt %q --arg key=value`.",
+			msg, name, name,
+		)
+	}
+	return fmt.Errorf("%s", msg)
 }

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
@@ -48,3 +50,38 @@ func TestGetGroupSubcommand(t *testing.T) {
 		}
 	})
 }
+
+func TestPrettifyGetPromptError(t *testing.T) {
+	t.Run("drops duplicated failed-to-get-prompt prefix", func(t *testing.T) {
+		// Mirrors the real wrapping chain from cmd/get.go + api/mcp_prompts.go +
+		// service/mcp/prompt.go: three stacked "failed to get prompt:" prefixes.
+		in := fmt.Errorf("failed to get prompt: failed to get prompt: failed to get prompt Dataset Details from MCP server hf: something broke")
+		got := prettifyGetPromptError("hf__Dataset Details", in).Error()
+		want := "failed to get prompt Dataset Details from MCP server hf: something broke"
+		if got != want {
+			t.Fatalf("prettifyGetPromptError mismatch\n got:  %q\n want: %q", got, want)
+		}
+	})
+
+	t.Run("appends --arg usage hint on MCP -32602", func(t *testing.T) {
+		// Real MCP server payload returned for a missing required argument.
+		in := fmt.Errorf("failed to get prompt: failed to get prompt Dataset Details from MCP server hf: invalid params: MCP error -32602: Invalid arguments for prompt Dataset Details: []")
+		got := prettifyGetPromptError("hf__Dataset Details", in).Error()
+		if strings.Contains(got, "failed to get prompt: failed to get prompt") {
+			t.Fatalf("prefix should have been collapsed, got: %q", got)
+		}
+		if !strings.Contains(got, "Hint:") || !strings.Contains(got, "--arg key=value") {
+			t.Fatalf("expected --arg usage hint, got: %q", got)
+		}
+	})
+
+	t.Run("passes non-MCP errors through unchanged (minus prefix)", func(t *testing.T) {
+		in := fmt.Errorf("failed to get prompt: request failed with status: 404, message: not found")
+		got := prettifyGetPromptError("hf__Missing", in).Error()
+		want := "request failed with status: 404, message: not found"
+		if got != want {
+			t.Fatalf("unexpected result\n got:  %q\n want: %q", got, want)
+		}
+	})
+}
+


### PR DESCRIPTION
## Summary

Collapse the stacked `failed to get prompt:` wrapping around `mcpjungle get prompt` errors, and surface an actionable `--arg key=value` hint when the upstream MCP server returns a JSON-RPC `-32602 / Invalid arguments` error. Addresses #214.

## Why

Today when a required argument is missing, the user sees this on stderr:

```
failed to get prompt: failed to get prompt: failed to get prompt Dataset Details from MCP server hf: invalid params: MCP error -32602: Invalid arguments for prompt Dataset Details: [
  {
    "code": "invalid_type",
    "expected": "object",
    "received": "undefined",
    "path": [],
    "message": "Required"
  }
]
```

Three problems stacked together:

1. **Triple wrapping.** `cmd/get.go:131`, `internal/api/mcp_prompts.go:80`, and `internal/service/mcp/prompt.go:125` each prepend `failed to get prompt:` / `failed to get prompt ...`. By the time the string reaches a terminal the prefix repeats three times.
2. **Raw Zod-style JSON array.** The user has no idea that the `invalid_type`/`received: undefined` block is telling them to supply an argument — there is no visible hint to use `--arg key=value`.
3. **No useful signal.** There is no suggestion of which argument is required, because the server-side error for missing `path: []` is generic and the client never parses it.

## Changes

Single file, `cmd/get.go`:

- `runGetPrompt` now returns `prettifyGetPromptError(name, err)` instead of `fmt.Errorf("failed to get prompt: %w", err)`.
- New helper `prettifyGetPromptError`:
  - Strips any stacked `failed to get prompt: ` prefixes (so you see one copy of the real message, not three).
  - Detects the MCP protocol shape `"-32602"` / `"Invalid arguments for prompt"` and appends a `Hint: ... --arg key=value ...` suggestion with the prompt name already filled in.
  - Everything else passes through with the outer prefix stripped — no behavioral change for non-MCP errors.

After the fix the same failure reads:

```
failed to get prompt Dataset Details from MCP server hf: invalid params: MCP error -32602: Invalid arguments for prompt Dataset Details: [...]

Hint: prompt "hf__Dataset Details" rejected the arguments you supplied. Pass required arguments with --arg key=value, e.g. `mcpjungle get prompt "hf__Dataset Details" --arg key=value`.
```

Server-side and service-side wrappers are untouched — they still carry the authoritative context for logs — only the CLI presentation layer changes.

## Testing

- Added three unit tests in `cmd/get_test.go`:
  - Triple-prefix collapse reduces to one copy of the underlying message.
  - MCP `-32602` path appends the `--arg` hint and removes the stacked prefix.
  - Non-MCP pass-through (HTTP 404) returns the underlying string intact.
- `go test ./...` passes across all packages (including e2e suite).

Fixes #214

This contribution was developed with AI assistance (Claude Code).

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
