### PR TITLE
feat: per-client Tool Group binding

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -48,6 +48,11 @@ const (
 )
 
 const (
+	// RequireClientTGBindingEnvVar is the environment variable that enables strict mode.
+	// When set to "true" or "1", POST /api/v0/clients requires a bound_tool_group, and
+	// clients with a bound_tool_group are blocked from the global /mcp endpoint.
+	RequireClientTGBindingEnvVar = "MCPJUNGLE_REQUIRE_CLIENT_TG_BINDING"
+
 	// McpServerInitReqTimeoutSecEnvVar is the environment variable for configuring
 	// the MCP server initialization request timeout.
 	McpServerInitReqTimeoutSecEnvVar = "MCP_SERVER_INIT_REQ_TIMEOUT_SEC"
@@ -436,17 +441,31 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to create Tool Group service: %v", err)
 	}
 
+	// Inject the tool-group lookup into the client service so it can validate bound_tool_group on create/update.
+	mcpClientService.SetToolGroupService(toolGroupService)
+	// Inject the bound-client checker into the tool group service so it can refuse to delete a group
+	// that still has clients bound to it.
+	toolGroupService.SetMcpClientChecker(mcpClientService)
+
+	// Determine whether strict binding mode is enabled.
+	requireClientTGBinding := false
+	if v := strings.ToLower(strings.TrimSpace(os.Getenv(RequireClientTGBindingEnvVar))); v == "true" || v == "1" {
+		requireClientTGBinding = true
+		log.Printf("[server] strict client tool-group binding mode is ENABLED (%s=true)\n", RequireClientTGBindingEnvVar)
+	}
+
 	// create the API server
 	opts := &api.ServerOptions{
-		MCPProxyServer:    mcpProxyServer,
-		SseMcpProxyServer: sseMcpProxyServer,
-		MCPService:        mcpService,
-		MCPClientService:  mcpClientService,
-		ConfigService:     configService,
-		UserService:       userService,
-		ToolGroupService:  toolGroupService,
-		OtelProviders:     otelProviders,
-		Metrics:           mcpMetrics,
+		MCPProxyServer:         mcpProxyServer,
+		SseMcpProxyServer:      sseMcpProxyServer,
+		MCPService:             mcpService,
+		MCPClientService:       mcpClientService,
+		ConfigService:          configService,
+		UserService:            userService,
+		ToolGroupService:       toolGroupService,
+		OtelProviders:          otelProviders,
+		Metrics:                mcpMetrics,
+		RequireClientTGBinding: requireClientTGBinding,
 	}
 	s, err := api.NewServer(opts)
 	if err != nil {

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -9,8 +9,9 @@ import (
 )
 
 // handleServiceError writes the appropriate HTTP error response for a service-layer error.
-// It maps apierrors.ErrNotFound to 404 not found
-// and apierrors.ErrInvalidInput to 400 bad request.
+// It maps apierrors.ErrNotFound to 404 not found,
+// apierrors.ErrInvalidInput to 400 bad request,
+// and apierrors.ErrConflict to 409 conflict.
 // all other errors become 500.
 func handleServiceError(c *gin.Context, err error) {
 	if errors.Is(err, apierrors.ErrNotFound) {
@@ -19,6 +20,10 @@ func handleServiceError(c *gin.Context, err error) {
 	}
 	if errors.Is(err, apierrors.ErrInvalidInput) {
 		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if errors.Is(err, apierrors.ErrConflict) {
+		c.JSON(http.StatusConflict, gin.H{"error": err.Error()})
 		return
 	}
 	c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/internal/api/mcp_clients.go
+++ b/internal/api/mcp_clients.go
@@ -29,6 +29,13 @@ func (s *Server) createMcpClientHandler() gin.HandlerFunc {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "name is required"})
 			return
 		}
+		// In strict mode, every new client must declare its bound tool group.
+		if s.requireClientTGBinding && req.BoundToolGroup == nil {
+			c.JSON(http.StatusBadRequest, gin.H{
+				"error": "bound_tool_group is required when MCPJUNGLE_REQUIRE_CLIENT_TG_BINDING is enabled",
+			})
+			return
+		}
 		// TODO: if allow list in the request is null, convert it to an empty JSON array
 		client, err := s.mcpClientService.CreateClient(req)
 		if err != nil {

--- a/internal/api/mcp_clients_test.go
+++ b/internal/api/mcp_clients_test.go
@@ -7,9 +7,99 @@ import (
 	"testing"
 
 	"github.com/gin-gonic/gin"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	mcpSvc "github.com/mcpjungle/mcpjungle/internal/service/mcp"
 	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
+	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
+	"github.com/mcpjungle/mcpjungle/internal/telemetry"
 	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
 )
+
+// setupMcpClientServer creates a Server wired with both McpClientService and ToolGroupService
+// so bound_tool_group validation works end-to-end in tests.
+func setupMcpClientServer(t *testing.T, requireBinding bool) (*Server, *testhelpers.TestDBSetup) {
+	t.Helper()
+	setup := testhelpers.SetupTestDB(t)
+	t.Cleanup(setup.Cleanup)
+
+	mcpProxy := mcpserver.NewMCPServer("test", "0.0.1")
+	sseMcpProxy := mcpserver.NewMCPServer("test-sse", "0.0.1")
+	svc, err := mcpSvc.NewMCPService(&mcpSvc.ServiceConfig{
+		DB:                      setup.DB,
+		McpProxyServer:          mcpProxy,
+		SseMcpProxyServer:       sseMcpProxy,
+		Metrics:                 telemetry.NewNoopCustomMetrics(),
+		McpServerInitReqTimeout: 5,
+	})
+	if err != nil {
+		t.Fatalf("failed to create MCP service: %v", err)
+	}
+	tgSvc, err := toolgroup.NewToolGroupService(setup.DB, svc)
+	if err != nil {
+		t.Fatalf("failed to create tool group service: %v", err)
+	}
+
+	clientSvc := mcpclient.NewMCPClientService(setup.DB)
+	clientSvc.SetToolGroupService(tgSvc)
+
+	s := &Server{
+		mcpClientService:       clientSvc,
+		requireClientTGBinding: requireBinding,
+	}
+	return s, setup
+}
+
+func TestCreateMcpClientHandler_StrictMode_RequiresBoundToolGroup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s, _ := setupMcpClientServer(t, true /* strict */)
+
+	router := gin.New()
+	router.POST("/clients", s.createMcpClientHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/clients",
+		strings.NewReader(`{"name":"my-client"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusBadRequest, w.Code)
+	testhelpers.AssertStringContains(t, w.Body.String(), "bound_tool_group")
+}
+
+func TestCreateMcpClientHandler_NonStrictMode_NoBoundToolGroupAllowed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s, _ := setupMcpClientServer(t, false /* non-strict */)
+
+	router := gin.New()
+	router.POST("/clients", s.createMcpClientHandler())
+
+	req := httptest.NewRequest(http.MethodPost, "/clients",
+		strings.NewReader(`{"name":"my-client"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Without strict mode, a client can be created without bound_tool_group.
+	testhelpers.AssertEqual(t, http.StatusCreated, w.Code)
+}
+
+func TestCreateMcpClientHandler_NonExistentBoundToolGroup_Returns400(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s, _ := setupMcpClientServer(t, false)
+
+	router := gin.New()
+	router.POST("/clients", s.createMcpClientHandler())
+
+	// Request a non-existent bound_tool_group — should fail with 400.
+	req := httptest.NewRequest(http.MethodPost, "/clients",
+		strings.NewReader(`{"name":"my-client","bound_tool_group":"ghost-group"}`))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusBadRequest, w.Code)
+	testhelpers.AssertStringContains(t, w.Body.String(), "ghost-group")
+}
 
 func TestUpdateMcpClientHandler_NotFound(t *testing.T) {
 	gin.SetMode(gin.TestMode)

--- a/internal/api/middleware.go
+++ b/internal/api/middleware.go
@@ -136,6 +136,88 @@ func (s *Server) requireServerMode(m model.ServerMode) gin.HandlerFunc {
 	}
 }
 
+// blockBoundClientsFromGlobalMCP is middleware for the global /mcp endpoint.
+// When RequireClientTGBinding (strict mode) is enabled, it rejects clients that have a BoundToolGroup
+// set — those clients must use the group-specific endpoint, not the global one.
+// This middleware must run after checkAuthForMcpProxyAccess.
+func (s *Server) blockBoundClientsFromGlobalMCP() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if !s.requireClientTGBinding {
+			c.Next()
+			return
+		}
+
+		raw := c.Request.Context().Value("client")
+		if raw == nil {
+			// dev mode or unauthenticated — let through (other middleware handles auth)
+			c.Next()
+			return
+		}
+		client, ok := raw.(*model.McpClient)
+		if !ok || client == nil {
+			c.Next()
+			return
+		}
+
+		if client.BoundToolGroup != nil {
+			c.AbortWithStatusJSON(
+				http.StatusForbidden,
+				gin.H{
+					"error": fmt.Sprintf(
+						"client %q is bound to tool group %q and must use the group-specific endpoint /v0/groups/%s/mcp",
+						client.Name, *client.BoundToolGroup, *client.BoundToolGroup,
+					),
+				},
+			)
+			return
+		}
+		c.Next()
+	}
+}
+
+// enforceToolGroupBinding is middleware that restricts a bound MCP client to its designated Tool Group.
+// It must run after checkAuthForMcpProxyAccess (which injects the client into the request context).
+// If the client has a BoundToolGroup set, the URL parameter :name must match it exactly.
+// Clients without a binding (BoundToolGroup == nil) may access any group endpoint (legacy behaviour).
+// In dev mode the middleware is a no-op (no client is injected into context).
+func (s *Server) enforceToolGroupBinding() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		// Retrieve the client injected by checkAuthForMcpProxyAccess.
+		// In dev mode the client is not injected, so we skip enforcement.
+		raw := c.Request.Context().Value("client")
+		if raw == nil {
+			c.Next()
+			return
+		}
+		client, ok := raw.(*model.McpClient)
+		if !ok || client == nil {
+			c.Next()
+			return
+		}
+
+		if client.BoundToolGroup == nil {
+			// Unbound client — legacy behaviour, allow access to any group.
+			c.Next()
+			return
+		}
+
+		groupName := c.Param("name")
+		if *client.BoundToolGroup != groupName {
+			c.AbortWithStatusJSON(
+				http.StatusForbidden,
+				gin.H{
+					"error": fmt.Sprintf(
+						"client %q is bound to tool group %q and may not access group %q",
+						client.Name, *client.BoundToolGroup, groupName,
+					),
+				},
+			)
+			return
+		}
+		c.Next()
+	}
+}
+
 // checkAuthForMcpProxyAccess is middleware for MCP proxy that checks for a valid MCP client token
 // if the server is in enterprise mode.
 // In development mode, mcp clients do not require auth to access the MCP proxy.

--- a/internal/api/middleware_test.go
+++ b/internal/api/middleware_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -494,4 +495,148 @@ func TestMiddlewareIntegration(t *testing.T) {
 	if w.Body.String() != expectedBody {
 		t.Errorf("Expected body %s, got %s", expectedBody, w.Body.String())
 	}
+}
+
+// injectClientIntoRequest returns a copy of req with the McpClient injected into its context,
+// simulating what checkAuthForMcpProxyAccess does in the real request path.
+func injectClientIntoRequest(req *http.Request, client *model.McpClient) *http.Request {
+	ctx := context.WithValue(req.Context(), "client", client)
+	return req.WithContext(ctx)
+}
+
+// strPtr is a convenience helper for *string literals in tests.
+func strPtr(s string) *string { return &s }
+
+// TestEnforceToolGroupBinding_BoundClientMatchingGroup verifies that a client bound to "grp-a"
+// can reach /groups/grp-a/* without being blocked.
+func TestEnforceToolGroupBinding_BoundClientMatchingGroup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+
+	router := gin.New()
+	router.GET("/groups/:name/mcp", s.enforceToolGroupBinding(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	client := &model.McpClient{Name: "c1", BoundToolGroup: strPtr("grp-a")}
+	req := injectClientIntoRequest(httptest.NewRequest(http.MethodGet, "/groups/grp-a/mcp", nil), client)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusOK, w.Code)
+}
+
+// TestEnforceToolGroupBinding_BoundClientWrongGroup verifies that a client bound to "grp-a"
+// gets 403 when it tries to access /groups/grp-b/*.
+func TestEnforceToolGroupBinding_BoundClientWrongGroup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+
+	router := gin.New()
+	router.GET("/groups/:name/mcp", s.enforceToolGroupBinding(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	client := &model.McpClient{Name: "c1", BoundToolGroup: strPtr("grp-a")}
+	req := injectClientIntoRequest(httptest.NewRequest(http.MethodGet, "/groups/grp-b/mcp", nil), client)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusForbidden, w.Code)
+	testhelpers.AssertStringContains(t, w.Body.String(), "grp-a")
+}
+
+// TestEnforceToolGroupBinding_UnboundClientAnyGroup verifies that a client with no BoundToolGroup
+// (legacy/unbound) can reach any group endpoint — backwards-compat path.
+func TestEnforceToolGroupBinding_UnboundClientAnyGroup(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+
+	router := gin.New()
+	router.GET("/groups/:name/mcp", s.enforceToolGroupBinding(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	client := &model.McpClient{Name: "legacy", BoundToolGroup: nil}
+	req := injectClientIntoRequest(httptest.NewRequest(http.MethodGet, "/groups/any-group/mcp", nil), client)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusOK, w.Code)
+}
+
+// TestEnforceToolGroupBinding_DevModeNoClient verifies that the middleware is a no-op when no
+// client is in the context (dev mode — checkAuthForMcpProxyAccess skips injection).
+func TestEnforceToolGroupBinding_DevModeNoClient(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{}
+
+	router := gin.New()
+	router.GET("/groups/:name/mcp", s.enforceToolGroupBinding(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/groups/any-group/mcp", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusOK, w.Code)
+}
+
+// TestBlockBoundClientsFromGlobalMCP_StrictMode_BoundClientBlocked verifies that in strict mode
+// a client with BoundToolGroup is rejected from the global /mcp endpoint.
+func TestBlockBoundClientsFromGlobalMCP_StrictMode_BoundClientBlocked(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{requireClientTGBinding: true}
+
+	router := gin.New()
+	router.POST("/mcp", s.blockBoundClientsFromGlobalMCP(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	client := &model.McpClient{Name: "c1", BoundToolGroup: strPtr("code")}
+	req := injectClientIntoRequest(httptest.NewRequest(http.MethodPost, "/mcp", nil), client)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusForbidden, w.Code)
+	testhelpers.AssertStringContains(t, w.Body.String(), "code")
+}
+
+// TestBlockBoundClientsFromGlobalMCP_StrictMode_UnboundClientAllowed verifies that in strict mode
+// a client without BoundToolGroup can still hit the global /mcp endpoint.
+func TestBlockBoundClientsFromGlobalMCP_StrictMode_UnboundClientAllowed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{requireClientTGBinding: true}
+
+	router := gin.New()
+	router.POST("/mcp", s.blockBoundClientsFromGlobalMCP(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	client := &model.McpClient{Name: "legacy", BoundToolGroup: nil}
+	req := injectClientIntoRequest(httptest.NewRequest(http.MethodPost, "/mcp", nil), client)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusOK, w.Code)
+}
+
+// TestBlockBoundClientsFromGlobalMCP_NonStrictMode_BoundClientAllowed verifies that when strict
+// mode is OFF, even a bound client can reach the global /mcp endpoint.
+func TestBlockBoundClientsFromGlobalMCP_NonStrictMode_BoundClientAllowed(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s := &Server{requireClientTGBinding: false}
+
+	router := gin.New()
+	router.POST("/mcp", s.blockBoundClientsFromGlobalMCP(), func(c *gin.Context) {
+		c.JSON(http.StatusOK, gin.H{"ok": true})
+	})
+
+	client := &model.McpClient{Name: "c1", BoundToolGroup: strPtr("code")}
+	req := injectClientIntoRequest(httptest.NewRequest(http.MethodPost, "/mcp", nil), client)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusOK, w.Code)
 }

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -45,6 +45,11 @@ type ServerOptions struct {
 
 	OtelProviders *telemetry.Providers
 	Metrics       telemetry.CustomMetrics
+
+	// RequireClientTGBinding enables strict mode (env MCPJUNGLE_REQUIRE_CLIENT_TG_BINDING).
+	// When true: POST /api/v0/clients requires a bound_tool_group field,
+	// and clients with a BoundToolGroup are blocked from the global /mcp endpoint.
+	RequireClientTGBinding bool
 }
 
 // Server represents the MCPJungle registry server that handles MCP proxy and API requests
@@ -64,6 +69,9 @@ type Server struct {
 	otelProviders *telemetry.Providers
 	metrics       telemetry.CustomMetrics
 
+	// requireClientTGBinding mirrors ServerOptions.RequireClientTGBinding.
+	requireClientTGBinding bool
+
 	// groupMcpServers keeps track of mcp-go's server.SSEServer instances created for each tool group.
 	// These instances serve the requests made to tool groups' SSE tools.
 	// We need to maintain one instance for each group for sse to work correctly.
@@ -73,15 +81,16 @@ type Server struct {
 // NewServer initializes a new Gin server for MCPJungle registry and MCP proxy
 func NewServer(opts *ServerOptions) (*Server, error) {
 	s := &Server{
-		mcpProxyServer:    opts.MCPProxyServer,
-		sseMcpProxyServer: opts.SseMcpProxyServer,
-		mcpService:        opts.MCPService,
-		mcpClientService:  opts.MCPClientService,
-		configService:     opts.ConfigService,
-		userService:       opts.UserService,
-		toolGroupService:  opts.ToolGroupService,
-		otelProviders:     opts.OtelProviders,
-		metrics:           opts.Metrics,
+		mcpProxyServer:         opts.MCPProxyServer,
+		sseMcpProxyServer:      opts.SseMcpProxyServer,
+		mcpService:             opts.MCPService,
+		mcpClientService:       opts.MCPClientService,
+		configService:          opts.ConfigService,
+		userService:            opts.UserService,
+		toolGroupService:       opts.ToolGroupService,
+		otelProviders:          opts.OtelProviders,
+		metrics:                opts.Metrics,
+		requireClientTGBinding: opts.RequireClientTGBinding,
 	}
 
 	// Set up the router after the server is fully initialized
@@ -176,6 +185,7 @@ func (s *Server) setupRouter() (*gin.Engine, error) {
 		"/mcp",
 		s.requireInitialized(),
 		s.checkAuthForMcpProxyAccess(),
+		s.blockBoundClientsFromGlobalMCP(),
 		gin.WrapH(streamableHTTPServer),
 	)
 
@@ -183,6 +193,7 @@ func (s *Server) setupRouter() (*gin.Engine, error) {
 		V0PathPrefix+"/groups/:name/mcp",
 		s.requireInitialized(),
 		s.checkAuthForMcpProxyAccess(),
+		s.enforceToolGroupBinding(),
 		s.toolGroupMCPServerCallHandler(),
 	)
 
@@ -205,12 +216,14 @@ func (s *Server) setupRouter() (*gin.Engine, error) {
 		V0PathPrefix+"/groups/:name/sse",
 		s.requireInitialized(),
 		s.checkAuthForMcpProxyAccess(),
+		s.enforceToolGroupBinding(),
 		s.toolGroupSseMCPServerCallHandler(),
 	)
 	r.Any(
 		V0PathPrefix+"/groups/:name/message",
 		s.requireInitialized(),
 		s.checkAuthForMcpProxyAccess(),
+		s.enforceToolGroupBinding(),
 		s.toolGroupSseMCPServerCallMessageHandler(),
 	)
 

--- a/internal/api/tool_groups_test.go
+++ b/internal/api/tool_groups_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 	mcpserver "github.com/mark3labs/mcp-go/server"
 	mcpSvc "github.com/mcpjungle/mcpjungle/internal/service/mcp"
+	"github.com/mcpjungle/mcpjungle/internal/service/mcpclient"
 	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
 	"github.com/mcpjungle/mcpjungle/internal/telemetry"
 	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
@@ -71,4 +72,76 @@ func TestUpdateToolGroupHandler_NotFound(t *testing.T) {
 
 	testhelpers.AssertEqual(t, http.StatusNotFound, w.Code)
 	testhelpers.AssertStringContains(t, w.Body.String(), "not found")
+}
+
+// setupToolGroupServerWithClients creates a Server backed by both a ToolGroupService and an
+// McpClientService, with the cross-service bound-client checker wired in.
+func setupToolGroupServerWithClients(t *testing.T) (*Server, *testhelpers.TestDBSetup) {
+	t.Helper()
+	setup := testhelpers.SetupTestDB(t)
+	t.Cleanup(setup.Cleanup)
+
+	mcpProxy := mcpserver.NewMCPServer("test", "0.0.1")
+	sseMcpProxy := mcpserver.NewMCPServer("test-sse", "0.0.1")
+	svc, err := mcpSvc.NewMCPService(&mcpSvc.ServiceConfig{
+		DB:                      setup.DB,
+		McpProxyServer:          mcpProxy,
+		SseMcpProxyServer:       sseMcpProxy,
+		Metrics:                 telemetry.NewNoopCustomMetrics(),
+		McpServerInitReqTimeout: 5,
+	})
+	if err != nil {
+		t.Fatalf("failed to create MCP service: %v", err)
+	}
+
+	tgSvc, err := toolgroup.NewToolGroupService(setup.DB, svc)
+	if err != nil {
+		t.Fatalf("failed to create tool group service: %v", err)
+	}
+
+	clientSvc := mcpclient.NewMCPClientService(setup.DB)
+	clientSvc.SetToolGroupService(tgSvc)
+	tgSvc.SetMcpClientChecker(clientSvc)
+
+	return &Server{toolGroupService: tgSvc, mcpClientService: clientSvc}, setup
+}
+
+// TestDeleteToolGroupHandler_ConflictWhenClientsBound verifies that deleting a Tool Group
+// returns 409 Conflict when at least one MCP client is bound to it.
+func TestDeleteToolGroupHandler_ConflictWhenClientsBound(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s, setup := setupToolGroupServerWithClients(t)
+
+	// Seed a bound client directly in the DB (bypassing service validation for simplicity).
+	groupName := "my-group"
+	setup.CreateTestMcpClientBound("bound-client", "desc", "token-abc", nil, &groupName)
+
+	router := gin.New()
+	router.DELETE("/groups/:name", s.deleteToolGroupHandler())
+
+	req := httptest.NewRequest(http.MethodDelete, "/groups/my-group", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	testhelpers.AssertEqual(t, http.StatusConflict, w.Code)
+	testhelpers.AssertStringContains(t, w.Body.String(), "bound")
+}
+
+// TestDeleteToolGroupHandler_SucceedsWhenNoClientsBound verifies that deleting a Tool Group
+// that has no bound clients succeeds (404 because the group doesn't exist in this test, but
+// the 409 path is NOT triggered).
+func TestDeleteToolGroupHandler_NoBoundClients_NoConflict(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	s, _ := setupToolGroupServerWithClients(t)
+
+	router := gin.New()
+	router.DELETE("/groups/:name", s.deleteToolGroupHandler())
+
+	// No clients bound — delete of a non-existent group should return 204 (idempotent), not 409.
+	req := httptest.NewRequest(http.MethodDelete, "/groups/empty-group", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// Must NOT be 409 Conflict.
+	testhelpers.AssertTrue(t, w.Code != http.StatusConflict, "expected no 409 when no clients are bound")
 }

--- a/internal/model/mcp_client.go
+++ b/internal/model/mcp_client.go
@@ -21,6 +21,11 @@ type McpClient struct {
 	// storing the list of server names as a JSON array is a convenient way for now.
 	// In the future, this will be removed in favor of a separate table for ACLs.
 	AllowList datatypes.JSON `json:"allow_list" gorm:"type:jsonb; not null"`
+
+	// BoundToolGroup is the name of the Tool Group this client is restricted to.
+	// When non-nil, the client may only access the /v0/groups/<name>/* endpoints
+	// where <name> matches this value. NULL means no restriction (legacy behaviour).
+	BoundToolGroup *string `json:"bound_tool_group,omitempty" gorm:"column:bound_tool_group"`
 }
 
 // CheckHasServerAccess returns true if this client has access to the specified MCP server.

--- a/internal/service/mcpclient/mcp_client.go
+++ b/internal/service/mcpclient/mcp_client.go
@@ -11,13 +11,26 @@ import (
 	"gorm.io/gorm"
 )
 
+// ToolGroupLookup is the interface McpClientService needs to validate bound_tool_group values.
+// It is satisfied by *toolgroup.ToolGroupService.
+type ToolGroupLookup interface {
+	GetToolGroup(name string) (*model.ToolGroup, error)
+}
+
 // McpClientService provides methods to manage MCP clients in the database.
 type McpClientService struct {
-	db *gorm.DB
+	db             *gorm.DB
+	toolGroupSvc   ToolGroupLookup // may be nil when tool-group features are not used
 }
 
 func NewMCPClientService(db *gorm.DB) *McpClientService {
 	return &McpClientService{db: db}
+}
+
+// SetToolGroupService injects the tool-group lookup dependency after construction.
+// This breaks the import cycle between mcpclient and toolgroup packages.
+func (m *McpClientService) SetToolGroupService(tgs ToolGroupLookup) {
+	m.toolGroupSvc = tgs
 }
 
 // ListClients retrieves all MCP clients known to mcpjungle from the database
@@ -52,10 +65,27 @@ func (m *McpClientService) CreateClient(client model.McpClient) (*model.McpClien
 		client.AllowList = []byte("[]")
 	}
 
+	// If a bound_tool_group is specified, verify that the group exists.
+	if client.BoundToolGroup != nil {
+		if m.toolGroupSvc == nil {
+			return nil, fmt.Errorf("tool group service is not available: %w", apierrors.ErrInvalidInput)
+		}
+		if _, err := m.toolGroupSvc.GetToolGroup(*client.BoundToolGroup); err != nil {
+			return nil, fmt.Errorf("bound_tool_group %q does not exist: %w", *client.BoundToolGroup, apierrors.ErrInvalidInput)
+		}
+	}
+
 	if err := m.db.Create(&client).Error; err != nil {
 		return nil, err
 	}
 	return &client, nil
+}
+
+// CountBoundClients returns the number of MCP clients bound to the specified tool group name.
+func (m *McpClientService) CountBoundClients(toolGroupName string) (int64, error) {
+	var count int64
+	err := m.db.Model(&model.McpClient{}).Where("bound_tool_group = ?", toolGroupName).Count(&count).Error
+	return count, err
 }
 
 // GetClientByToken retrieves an MCP client by its access token from the database.
@@ -79,7 +109,7 @@ func (m *McpClientService) DeleteClient(name string) error {
 }
 
 // UpdateClient updates an existing MCP client's information in the database.
-// Currently, it only supports updating the access token of the client.
+// Currently, it supports updating the access token and bound_tool_group of the client.
 func (m *McpClientService) UpdateClient(updatedClient model.McpClient) (*model.McpClient, error) {
 	var client model.McpClient
 	if err := m.db.Where("name = ?", updatedClient.Name).First(&client).Error; err != nil {
@@ -93,8 +123,19 @@ func (m *McpClientService) UpdateClient(updatedClient model.McpClient) (*model.M
 		return nil, fmt.Errorf("invalid access token: %v: %w", err, apierrors.ErrInvalidInput)
 	}
 
-	// Update only the access token for now
+	// If a new bound_tool_group is specified, verify that the group exists.
+	if updatedClient.BoundToolGroup != nil {
+		if m.toolGroupSvc == nil {
+			return nil, fmt.Errorf("tool group service is not available: %w", apierrors.ErrInvalidInput)
+		}
+		if _, err := m.toolGroupSvc.GetToolGroup(*updatedClient.BoundToolGroup); err != nil {
+			return nil, fmt.Errorf("bound_tool_group %q does not exist: %w", *updatedClient.BoundToolGroup, apierrors.ErrInvalidInput)
+		}
+	}
+
+	// Update access token and bound_tool_group
 	client.AccessToken = updatedClient.AccessToken
+	client.BoundToolGroup = updatedClient.BoundToolGroup
 
 	if err := m.db.Save(&client).Error; err != nil {
 		return nil, err

--- a/internal/service/toolgroup/toolgroup.go
+++ b/internal/service/toolgroup/toolgroup.go
@@ -21,6 +21,13 @@ import (
 
 var ErrToolGroupNotFound = fmt.Errorf("tool group not found: %w", apierrors.ErrNotFound)
 
+// McpClientBoundChecker is the interface ToolGroupService needs to check whether any clients are
+// bound to a Tool Group before allowing rename or delete.
+// It is satisfied by *mcpclient.McpClientService.
+type McpClientBoundChecker interface {
+	CountBoundClients(toolGroupName string) (int64, error)
+}
+
 // ValidGroupName is a regex that matches valid tool group names.
 // A valid tool group name must start with an alphanumeric character and can contain
 // alphanumeric characters, underscores, and hyphens.
@@ -32,6 +39,10 @@ type ToolGroupService struct {
 	db *gorm.DB
 
 	mcpService *mcp.MCPService
+
+	// mcpClientChecker is used to check whether any MCP clients are bound to a tool group
+	// before allowing rename or delete. May be nil if not configured.
+	mcpClientChecker McpClientBoundChecker
 
 	// mcpServers manages the MCP proxy servers for all the tool groups
 	// key: tool group name, value: MCP proxy server
@@ -66,6 +77,12 @@ func NewToolGroupService(db *gorm.DB, mcpService *mcp.MCPService) (*ToolGroupSer
 		return nil, fmt.Errorf("failed to initialize tool group MCP servers: %w", err)
 	}
 	return s, nil
+}
+
+// SetMcpClientChecker injects the bound-client checker dependency after construction.
+// This breaks the import cycle between toolgroup and mcpclient packages.
+func (s *ToolGroupService) SetMcpClientChecker(c McpClientBoundChecker) {
+	s.mcpClientChecker = c
 }
 
 // CreateToolGroup creates a new tool group in the database and a Proxy MCP server that just exposes the specified tools.
@@ -269,6 +286,20 @@ func (s *ToolGroupService) ListToolGroups() ([]model.ToolGroup, error) {
 }
 
 func (s *ToolGroupService) DeleteToolGroup(name string) error {
+	// Refuse to delete if any MCP clients are bound to this group.
+	if s.mcpClientChecker != nil {
+		count, err := s.mcpClientChecker.CountBoundClients(name)
+		if err != nil {
+			return fmt.Errorf("failed to check bound clients for tool group %q: %w", name, err)
+		}
+		if count > 0 {
+			return fmt.Errorf(
+				"%d client(s) are bound to tool group %q; revoke them first: %w",
+				count, name, apierrors.ErrConflict,
+			)
+		}
+	}
+
 	s.deleteToolGroupMCPServers(name)
 
 	err := s.db.Unscoped().Where("name = ?", name).Delete(&model.ToolGroup{}).Error

--- a/pkg/apierrors/errors.go
+++ b/pkg/apierrors/errors.go
@@ -9,3 +9,6 @@ var ErrNotFound = errors.New("not found")
 
 // ErrInvalidInput is returned by service methods when user input is invalid (e.g. invalid mcp tool name).
 var ErrInvalidInput = errors.New("invalid user input")
+
+// ErrConflict is returned by service methods when an operation cannot proceed due to a conflicting resource state.
+var ErrConflict = errors.New("conflict")

--- a/pkg/testhelpers/testhelpers.go
+++ b/pkg/testhelpers/testhelpers.go
@@ -323,6 +323,11 @@ func (s *TestDBSetup) CreateTestUser(username string, role types.UserRole, acces
 
 // CreateTestMcpClient creates a test MCP client with the given parameters
 func (s *TestDBSetup) CreateTestMcpClient(name, description, accessToken string, allowList []string) *model.McpClient {
+	return s.CreateTestMcpClientBound(name, description, accessToken, allowList, nil)
+}
+
+// CreateTestMcpClientBound creates a test MCP client with the given parameters and an optional BoundToolGroup.
+func (s *TestDBSetup) CreateTestMcpClientBound(name, description, accessToken string, allowList []string, boundToolGroup *string) *model.McpClient {
 	allowListJSON := []byte("[]")
 	if len(allowList) > 0 {
 		// Create a proper JSON array
@@ -338,10 +343,11 @@ func (s *TestDBSetup) CreateTestMcpClient(name, description, accessToken string,
 	}
 
 	client := &model.McpClient{
-		Name:        name,
-		Description: description,
-		AccessToken: accessToken,
-		AllowList:   allowListJSON,
+		Name:           name,
+		Description:    description,
+		AccessToken:    accessToken,
+		AllowList:      allowListJSON,
+		BoundToolGroup: boundToolGroup,
 	}
 
 	err := s.DB.Create(client).Error


### PR DESCRIPTION
# feat: per-client Tool Group binding

## Motivation

MCPJungle's Tool Group endpoints (`/v0/groups/<name>/mcp`) scope tools by URL,
but any valid bearer token can reach any group URL. For multi-tenant gateway
deployments — and specifically for LLM harnesses that have shell-tool access
(Claude Code, Gemini CLI, Codex, opencode) — this means the LLM can construct
an HTTP request to a privileged group endpoint using its own token and bypass
the intended scoping. This PR makes the per-session boot binding a hard contract
instead of an advisory one.

Threat model: a session token minted for the `code` (minimal) Tool Group must
not be usable against the `full` (rich) Tool Group even if the LLM discovers the
URL pattern. Endpoint-only scoping fails this for shell-capable harnesses.

## What changed

### New column

`McpClient.BoundToolGroup *string` — nullable GORM column (`bound_tool_group`).
NULL = legacy behaviour, no restriction. GORM AutoMigrate adds the column on
next startup; no manual migration needed.

### New middleware

**`enforceToolGroupBinding()`** — applied after `checkAuthForMcpProxyAccess` on
all `/v0/groups/:name/mcp`, `/v0/groups/:name/sse`, and `/v0/groups/:name/message`
routes. If the authenticated client has `BoundToolGroup` set and it does not
match the `:name` URL parameter, the request is rejected with **403 Forbidden**.
Clients with `BoundToolGroup = nil` pass through unchanged (backwards compat).

**`blockBoundClientsFromGlobalMCP()`** — applied after auth on the global `/mcp`
endpoint. Active only in strict mode (see below). Rejects bound clients from the
global endpoint with 403, directing them to their group-specific URL.

### Strict mode

`MCPJUNGLE_REQUIRE_CLIENT_TG_BINDING=true` (or `1`) enables strict mode:
- `POST /api/v0/clients` requires `bound_tool_group` in the request body (400 if absent).
- Bound clients are blocked from the global `/mcp` endpoint (403).
- Unbound clients and the group endpoints are unaffected.

manas-cli will run with this flag set so every session token is explicitly scoped.

### Tool Group delete protection

`ToolGroupService.DeleteToolGroup` now queries the number of clients bound to the
group before deleting. If any exist, it returns **409 Conflict** with a message
naming the count and instructing the caller to revoke the clients first.

### Rename protection

`UpdateToolGroup` already forces `updatedGroup.Name = name` (line 242), so
renames are structurally impossible through the existing API. No additional
change needed.

### Validation on create/update

`McpClientService.CreateClient` and `UpdateClient` validate that the named
`bound_tool_group` exists via a `ToolGroupLookup` interface
(`GetToolGroup(name)`). Returns 400 if the group does not exist.

The two service packages avoid a circular import via setter injection:
- `mcpClientService.SetToolGroupService(tgSvc)` — called in `runStartServer`
- `toolGroupService.SetMcpClientChecker(mcpClientService)` — called immediately after

## Backwards compatibility

- Existing clients with `BoundToolGroup = nil` keep working exactly as before.
  The middleware is a no-op for them on group routes, and strict mode does not
  affect them on the global `/mcp` endpoint.
- The new nullable column is additive; GORM AutoMigrate handles it.
- No existing API response shapes change.

## Tests added (9 new)

| Test | File | What it covers |
|---|---|---|
| `TestEnforceToolGroupBinding_BoundClientMatchingGroup` | `middleware_test.go` | Bound client, correct group → 200 |
| `TestEnforceToolGroupBinding_BoundClientWrongGroup` | `middleware_test.go` | Bound client, wrong group → 403 |
| `TestEnforceToolGroupBinding_UnboundClientAnyGroup` | `middleware_test.go` | Unbound client, any group → 200 (backwards compat) |
| `TestEnforceToolGroupBinding_DevModeNoClient` | `middleware_test.go` | Dev mode (no client in ctx) → 200 |
| `TestBlockBoundClientsFromGlobalMCP_StrictMode_BoundClientBlocked` | `middleware_test.go` | Strict mode + bound client → 403 on /mcp |
| `TestBlockBoundClientsFromGlobalMCP_StrictMode_UnboundClientAllowed` | `middleware_test.go` | Strict mode + unbound client → 200 on /mcp |
| `TestBlockBoundClientsFromGlobalMCP_NonStrictMode_BoundClientAllowed` | `middleware_test.go` | Non-strict mode + bound client → 200 on /mcp |
| `TestDeleteToolGroupHandler_ConflictWhenClientsBound` | `tool_groups_test.go` | Delete TG with bound clients → 409 |
| `TestDeleteToolGroupHandler_NoBoundClients_NoConflict` | `tool_groups_test.go` | Delete TG with no bound clients → not 409 |
| `TestCreateMcpClientHandler_StrictMode_RequiresBoundToolGroup` | `mcp_clients_test.go` | Strict mode, no bound_tool_group → 400 |
| `TestCreateMcpClientHandler_NonStrictMode_NoBoundToolGroupAllowed` | `mcp_clients_test.go` | Non-strict, no bound_tool_group → 201 |
| `TestCreateMcpClientHandler_NonExistentBoundToolGroup_Returns400` | `mcp_clients_test.go` | Non-existent group → 400 |

`go test ./...` — all packages pass.

## Follow-ups

1. **`UpdateClient` bound_tool_group support** — the `PUT /api/v0/clients/:name`
   handler currently only updates the access token (comment in code: "Update only
   the access token for now"). The service method handles `BoundToolGroup` updates
   correctly, but the API handler would need to be extended to fully support it.

2. **Global `/mcp` AllowList ACL** — the existing `AllowList`/`CheckHasServerAccess`
   mechanism on the global `/mcp` endpoint is orthogonal to this change. The comment
   in the model ("this will be removed in favor of a separate table for ACLs") still
   stands; this PR is a step toward that but does not replace the AllowList.

3. **SSE server caching** — `getGroupSseServer` stores SSE servers in a `sync.Map`
   keyed by group name; the binding check happens before the SSE server lookup, so
   there is no leakage. But the cached SSE server has no knowledge of the binding —
   if a bound client somehow bypasses the middleware it would reach the wrong server.
   The middleware is the correct enforcement point.

4. **CLI integration** — `manas-cli` should pass `bound_tool_group` in the
   `POST /api/v0/clients` body when minting a session token, and start with
   `MCPJUNGLE_REQUIRE_CLIENT_TG_BINDING=true` in production deployments.
