### PR TITLE
fix: tie proxy MCP server versions to mcpjungle server version

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -120,6 +120,32 @@ func init() {
 	rootCmd.AddCommand(startServerCmd)
 }
 
+func newProxyServers() (*server.MCPServer, *server.MCPServer) {
+	// Tie the advertised proxy version to the mcpjungle server version (from
+	// pkg/version) so the proxies always report the same version as the host
+	// process, instead of a hardcoded string.
+	proxyVersion := version.GetVersion()
+
+	mcpProxyServer := server.NewMCPServer(
+		"MCPJungle Proxy MCP Server",
+		proxyVersion,
+		server.WithResourceCapabilities(false, false),
+		server.WithToolCapabilities(true),
+		server.WithPromptCapabilities(true),
+		server.WithToolFilter(mcp.ProxyToolFilter),
+	)
+	sseMcpProxyServer := server.NewMCPServer(
+		"MCPJungle Proxy MCP Server for SSE transport",
+		proxyVersion,
+		server.WithResourceCapabilities(false, false),
+		server.WithToolCapabilities(true),
+		server.WithPromptCapabilities(true),
+		server.WithToolFilter(mcp.ProxyToolFilter),
+	)
+
+	return mcpProxyServer, sseMcpProxyServer
+}
+
 // getDesiredServerMode returns the desired server mode for mcpjungle server.
 // unless explicitly specified, the desired mode is dev
 func getDesiredServerMode(cmd *cobra.Command) (model.ServerMode, error) {
@@ -374,26 +400,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 
 	bindPort := getBindPort()
 
-	// create the MCP proxy servers. Tie the advertised proxy version to the
-	// mcpjungle server version (from pkg/version) so the proxies always report
-	// the same version as the host process, instead of a hardcoded string.
-	proxyVersion := version.GetVersion()
-	mcpProxyServer := server.NewMCPServer(
-		"MCPJungle Proxy MCP Server",
-		proxyVersion,
-		server.WithResourceCapabilities(false, false),
-		server.WithToolCapabilities(true),
-		server.WithPromptCapabilities(true),
-		server.WithToolFilter(mcp.ProxyToolFilter),
-	)
-	sseMcpProxyServer := server.NewMCPServer(
-		"MCPJungle Proxy MCP Server for SSE transport",
-		proxyVersion,
-		server.WithResourceCapabilities(false, false),
-		server.WithToolCapabilities(true),
-		server.WithPromptCapabilities(true),
-		server.WithToolFilter(mcp.ProxyToolFilter),
-	)
+	mcpProxyServer, sseMcpProxyServer := newProxyServers()
 
 	timeout, err := getMcpServerInitReqTimeout()
 	if err != nil {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -27,6 +27,7 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/service/toolgroup"
 	"github.com/mcpjungle/mcpjungle/internal/service/user"
 	"github.com/mcpjungle/mcpjungle/internal/telemetry"
+	"github.com/mcpjungle/mcpjungle/pkg/version"
 	"github.com/spf13/cobra"
 )
 
@@ -373,10 +374,13 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 
 	bindPort := getBindPort()
 
-	// create the MCP proxy servers
+	// create the MCP proxy servers. Tie the advertised proxy version to the
+	// mcpjungle server version (from pkg/version) so the proxies always report
+	// the same version as the host process, instead of a hardcoded string.
+	proxyVersion := version.GetVersion()
 	mcpProxyServer := server.NewMCPServer(
 		"MCPJungle Proxy MCP Server",
-		"0.0.1",
+		proxyVersion,
 		server.WithResourceCapabilities(false, false),
 		server.WithToolCapabilities(true),
 		server.WithPromptCapabilities(true),
@@ -384,7 +388,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 	)
 	sseMcpProxyServer := server.NewMCPServer(
 		"MCPJungle Proxy MCP Server for SSE transport",
-		"0.0.1",
+		proxyVersion,
 		server.WithResourceCapabilities(false, false),
 		server.WithToolCapabilities(true),
 		server.WithPromptCapabilities(true),

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -4,6 +4,9 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
+	"github.com/mcpjungle/mcpjungle/pkg/version"
 )
 
 func TestStartCommandStructure(t *testing.T) {
@@ -63,6 +66,23 @@ func TestStartCommandFlags(t *testing.T) {
 			t.Error("prod flag should have usage description")
 		}
 	})
+}
+
+func TestNewProxyServers_AdvertiseCurrentVersion(t *testing.T) {
+	mcpProxyServer, sseMcpProxyServer := newProxyServers()
+
+	testhelpers.AssertMCPServerInfo(
+		t,
+		mcpProxyServer,
+		"MCPJungle Proxy MCP Server",
+		version.GetVersion(),
+	)
+	testhelpers.AssertMCPServerInfo(
+		t,
+		sseMcpProxyServer,
+		"MCPJungle Proxy MCP Server for SSE transport",
+		version.GetVersion(),
+	)
 }
 
 // Helper to set and unset env vars for a test

--- a/internal/service/toolgroup/toolgroup.go
+++ b/internal/service/toolgroup/toolgroup.go
@@ -16,6 +16,7 @@ import (
 	"github.com/mcpjungle/mcpjungle/pkg/apierrors"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"github.com/mcpjungle/mcpjungle/pkg/util"
+	"github.com/mcpjungle/mcpjungle/pkg/version"
 	"gorm.io/gorm"
 )
 
@@ -295,10 +296,13 @@ func (s *ToolGroupService) GetToolGroupSseMCPServer(name string) (*server.MCPSer
 }
 
 // newMCPServer creates a new MCP proxy server for a given tool group name.
+// The advertised version is tied to the mcpjungle server version (pkg/version)
+// so each tool-group proxy reports the host's version instead of a hardcoded
+// string.
 func (s *ToolGroupService) newMCPServer(groupName string) *server.MCPServer {
 	return server.NewMCPServer(
 		fmt.Sprintf("MCPJungle proxy MCP server for tool group: %s", groupName),
-		"0.1.0",
+		version.GetVersion(),
 		server.WithResourceCapabilities(false, false),
 		server.WithToolCapabilities(true),
 		server.WithPromptCapabilities(true),
@@ -310,7 +314,7 @@ func (s *ToolGroupService) newMCPServer(groupName string) *server.MCPServer {
 func (s *ToolGroupService) newSseMCPServer(groupName string) *server.MCPServer {
 	return server.NewMCPServer(
 		fmt.Sprintf("MCPJungle proxy MCP server for SSE transport for tool group: %s", groupName),
-		"0.1.0",
+		version.GetVersion(),
 		server.WithResourceCapabilities(false, false),
 		server.WithToolCapabilities(true),
 		server.WithPromptCapabilities(true),

--- a/internal/service/toolgroup/toolgroup_test.go
+++ b/internal/service/toolgroup/toolgroup_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mcpjungle/mcpjungle/internal/telemetry"
 	"github.com/mcpjungle/mcpjungle/pkg/apierrors"
 	"github.com/mcpjungle/mcpjungle/pkg/testhelpers"
+	"github.com/mcpjungle/mcpjungle/pkg/version"
 	"gorm.io/datatypes"
 	"gorm.io/gorm"
 )
@@ -350,4 +351,26 @@ func TestCreateToolGroup_InvalidIncludedServerStillFailsFast(t *testing.T) {
 	if !testhelpers.Contains(err.Error(), "failed to resolve effective tools") {
 		t.Fatalf("expected create error to mention failed resolution, got: %v", err)
 	}
+}
+
+func TestNewMCPServer_AdvertisesCurrentVersion(t *testing.T) {
+	s := &ToolGroupService{}
+
+	testhelpers.AssertMCPServerInfo(
+		t,
+		s.newMCPServer("group-a"),
+		"MCPJungle proxy MCP server for tool group: group-a",
+		version.GetVersion(),
+	)
+}
+
+func TestNewSseMCPServer_AdvertisesCurrentVersion(t *testing.T) {
+	s := &ToolGroupService{}
+
+	testhelpers.AssertMCPServerInfo(
+		t,
+		s.newSseMCPServer("group-a"),
+		"MCPJungle proxy MCP server for SSE transport for tool group: group-a",
+		version.GetVersion(),
+	)
 }

--- a/pkg/testhelpers/testhelpers.go
+++ b/pkg/testhelpers/testhelpers.go
@@ -3,10 +3,14 @@
 package testhelpers
 
 import (
+	"context"
+	"encoding/json"
 	"fmt"
 	"testing"
 
 	"github.com/glebarez/sqlite"
+	"github.com/mark3labs/mcp-go/mcp"
+	"github.com/mark3labs/mcp-go/server"
 	"github.com/mcpjungle/mcpjungle/internal/model"
 	"github.com/mcpjungle/mcpjungle/pkg/types"
 	"gorm.io/gorm"
@@ -38,6 +42,47 @@ func AssertNotNil(t *testing.T, obj any) {
 	t.Helper()
 	if obj == nil {
 		t.Error("Expected not nil, got nil")
+	}
+}
+
+// AssertMCPServerInfo asserts the MCP initialize response advertises the
+// expected server name and version.
+func AssertMCPServerInfo(t *testing.T, srv *server.MCPServer, expectedName, expectedVersion string) {
+	t.Helper()
+
+	message := mcp.JSONRPCRequest{
+		JSONRPC: mcp.JSONRPC_VERSION,
+		ID:      mcp.NewRequestId(int64(1)),
+		Request: mcp.Request{
+			Method: string(mcp.MethodInitialize),
+		},
+	}
+
+	messageBytes, err := json.Marshal(message)
+	if err != nil {
+		t.Fatalf("failed to marshal initialize request: %v", err)
+	}
+
+	response := srv.HandleMessage(context.Background(), messageBytes)
+	if response == nil {
+		t.Fatal("expected initialize response, got nil")
+	}
+
+	resp, ok := response.(mcp.JSONRPCResponse)
+	if !ok {
+		t.Fatalf("expected JSONRPCResponse, got %T", response)
+	}
+
+	initResult, ok := resp.Result.(mcp.InitializeResult)
+	if !ok {
+		t.Fatalf("expected InitializeResult, got %T", resp.Result)
+	}
+
+	if initResult.ServerInfo.Name != expectedName {
+		t.Fatalf("expected server name %q, got %q", expectedName, initResult.ServerInfo.Name)
+	}
+	if initResult.ServerInfo.Version != expectedVersion {
+		t.Fatalf("expected server version %q, got %q", expectedVersion, initResult.ServerInfo.Version)
 	}
 }
 


### PR DESCRIPTION
Closes #248.

`cmd/start.go` and `internal/service/toolgroup/toolgroup.go` each construct MCP proxy servers with a hardcoded version string. The strings were also inconsistent:

- `cmd/start.go` (main + SSE proxy): `"0.0.1"`
- `internal/service/toolgroup/toolgroup.go` (`newMCPServer` + `newSseMCPServer`): `"0.1.0"`

So the version reported by every proxy drifts from the actual mcpjungle build, and the two proxy families don't even agree with each other.

`pkg/version` already exists for exactly this: `version.GetVersion()` resolves the build-time `-ldflags="-X ...Version=..."` override, falls back to `debug.ReadBuildInfo()`, and finally to `"dev"`, then runs `NormalizeVersion` to keep the "v"-prefix shape consistent.

Replace the four hardcoded literals with `version.GetVersion()`. In `start.go` the value is read once into a local `proxyVersion` so the main and SSE proxies stay in lockstep.

Test files (`internal/api/*_test.go`, `internal/integration_test.go`, `internal/service/toolgroup/toolgroup_test.go`, `internal/e2e/helpers_test.go`) keep their hardcoded `"0.0.1"` fixtures - they're asserting against fixed values, not the runtime build version, so changing them would just churn the tests.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./internal/service/toolgroup/ ./cmd/ ./internal/api/... ./pkg/version/ ./pkg/util/` all pass
- [x] Diff is +13/-5 across two files, no test churn