### PR TITLE
fix(api): reuse StreamableHTTPServer per tool group for /mcp sessions

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -74,6 +74,12 @@ type Server struct {
 	// We need to maintain one instance for each group for sse to work correctly.
 	groupSseServers sync.Map
 
+	// groupStreamableServers keeps track of mcp-go's StreamableHTTPServer instances
+	// created for each tool group. These instances serve requests to tool groups'
+	// /mcp endpoints. We need to maintain one instance per group for the Streamable
+	// HTTP protocol to work correctly (session state must persist across requests).
+	groupStreamableServers sync.Map
+
 	// dashboardOAuthMu guards dashboardOAuthResults, which is a short-lived
 	// in-memory cache used by the browser-based dashboard OAuth flow.
 	dashboardOAuthMu sync.Mutex

--- a/internal/api/tool_groups.go
+++ b/internal/api/tool_groups.go
@@ -288,20 +288,17 @@ func (s *Server) updateToolGroupHandler() gin.HandlerFunc {
 // toolGroupMCPServerCallHandler handles incoming MCP requests from for a specific tool group.
 func (s *Server) toolGroupMCPServerCallHandler() gin.HandlerFunc {
 	return func(c *gin.Context) {
-		// get the Proxy MCP server for the specified tool group
 		groupName := c.Param("name")
-		groupMcpServer, exists := s.toolGroupService.GetToolGroupMCPServer(groupName)
-		if !exists {
-			c.JSON(http.StatusNotFound, gin.H{"error": fmt.Sprintf("tool group not found: %s", groupName)})
+
+		streamableServer, err := s.getGroupStreamableServer(groupName)
+		if err != nil {
+			c.JSON(
+				http.StatusNotFound,
+				gin.H{"error": fmt.Sprintf("failed to get streamable server for group %s: %v", groupName, err)},
+			)
 			return
 		}
 
-		// serve the MCP request using the MCP server
-		// TODO: Make this API more efficient
-		// This api sits in the hot path because we expect high traffic on MCP tool calling.
-		// It is inefficient to create a new StreamableHTTPServer for each request.
-		// Maybe pre-create a StreamableHTTPServer for each tool group and store it in the ToolGroupMCPServer struct?
-		streamableServer := server.NewStreamableHTTPServer(groupMcpServer)
 		streamableServer.ServeHTTP(c.Writer, c.Request)
 	}
 }
@@ -333,6 +330,30 @@ func (s *Server) getGroupSseServer(groupName string) (*server.SSEServer, error) 
 	s.groupSseServers.Store(groupName, sseServer)
 
 	return sseServer, nil
+}
+
+// getGroupStreamableServer returns a StreamableHTTPServer for a specific group,
+// creating one if it doesn't already exist. It ensures that each tool group has
+// its own StreamableHTTPServer instance to maintain session state across requests.
+func (s *Server) getGroupStreamableServer(groupName string) (*server.StreamableHTTPServer, error) {
+	// Try to get existing server first
+	if serverVal, ok := s.groupStreamableServers.Load(groupName); ok {
+		return serverVal.(*server.StreamableHTTPServer), nil
+	}
+
+	// Get the MCP proxy server for the group
+	groupMcpServer, exists := s.toolGroupService.GetToolGroupMCPServer(groupName)
+	if !exists {
+		return nil, fmt.Errorf("tool group not found: %s", groupName)
+	}
+
+	// Create new StreamableHTTPServer
+	streamableServer := server.NewStreamableHTTPServer(groupMcpServer)
+
+	// Store for future use
+	s.groupStreamableServers.Store(groupName, streamableServer)
+
+	return streamableServer, nil
 }
 
 // toolGroupSseMCPServerCallHandler handles SSE connection requests (/sse) for a specific tool group.


### PR DESCRIPTION
## Summary

Creating a new StreamableHTTPServer on every group /mcp request dropped instance session state between POST initialize and GET SSE, causing 400 (Session registration failed). Cache one server per group, matching the existing SSE and global /mcp patterns.

## Pre-Agreement Checklist (required)

Please check all boxes before requesting review:

- [x ] I have read and followed the [contribution guidelines](https://docs.mcpjungle.com/developers/contributing).
- [ x] This PR addresses an existing issue or a concluded discussion.
- [ x] If there was no existing issue/discussion, I opened one first to align with maintainers before submitting this PR.
- [ x] I confirmed the issue/discussion priority with maintainers and understand low-priority items may receive limited attention.
- [ x] I kept this PR focused and reasonably small; if the work is large, I split it into smaller PRs where possible.
- [ x] Any AI-generated code in this PR was reviewed by a human author.

## Validation Checklist

- [ x] `go test ./...` passes locally.
- [ x] `scripts/test-mcpjungle.sh` passes locally.
- [ x] I added or updated tests for new behavior where applicable.
- [ x] I updated documentation for user-facing changes where applicable.

## Linked Context

- Issue(s): #268 
- Discussion(s): https://github.com/mcpjungle/MCPJungle/issues/268
