### PR TITLE
feat(cli): add config validation command

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/mcpjungle/mcpjungle/internal/service/configvalidation"
+	"github.com/spf13/cobra"
+)
+
+var validateCmdConfigType string
+
+var validateCmd = &cobra.Command{
+	Use:   "validate <file>",
+	Args:  cobra.ExactArgs(1),
+	Short: "Validate an MCPJungle JSON config file",
+	Long: "Validate an MCPJungle JSON config file before using it with register or create commands.\n" +
+		"By default, the command infers the config type from its fields. Use --type to validate\n" +
+		"ambiguous files as one of: mcp-server, tool-group, mcp-client, user.",
+	Annotations: map[string]string{
+		"group": string(subCommandGroupBasic),
+		"order": "6",
+	},
+	RunE: runValidateConfig,
+}
+
+func init() {
+	validateCmd.Flags().StringVar(
+		&validateCmdConfigType,
+		"type",
+		"",
+		"Config type to validate as: mcp-server, tool-group, mcp-client, or user",
+	)
+
+	rootCmd.AddCommand(validateCmd)
+}
+
+func runValidateConfig(cmd *cobra.Command, args []string) error {
+	filePath := args[0]
+
+	var (
+		result *configvalidation.Result
+		err    error
+	)
+	if validateCmdConfigType == "" {
+		result, err = configvalidation.ValidateFile(filePath)
+	} else {
+		result, err = configvalidation.ValidateFileAs(filePath, configvalidation.ConfigType(validateCmdConfigType))
+	}
+	if err != nil {
+		return fmt.Errorf("failed to validate config: %w", err)
+	}
+
+	cmd.Printf("%s is a valid MCPJungle config (%s)\n", filePath, result.Type)
+	return nil
+}

--- a/cmd/validate_test.go
+++ b/cmd/validate_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestValidateCommandStructure(t *testing.T) {
+	t.Parallel()
+
+	if validateCmd.Use != "validate <file>" {
+		t.Fatalf("expected validate command Use to be %q, got %q", "validate <file>", validateCmd.Use)
+	}
+	if validateCmd.Short != "Validate an MCPJungle JSON config file" {
+		t.Fatalf("unexpected validate command Short: %q", validateCmd.Short)
+	}
+	if validateCmd.RunE == nil {
+		t.Fatal("validate command missing RunE")
+	}
+	if validateCmd.Annotations["group"] != string(subCommandGroupBasic) {
+		t.Fatalf("expected validate command in basic group, got %q", validateCmd.Annotations["group"])
+	}
+}
+
+func TestRunValidateConfigPrintsDetectedType(t *testing.T) {
+	t.Parallel()
+
+	file := writeValidateTestConfig(t, `{
+		"name": "context7",
+		"transport": "streamable_http",
+		"url": "https://mcp.context7.com/mcp"
+	}`)
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+
+	if err := runValidateConfig(cmd, []string{file}); err != nil {
+		t.Fatalf("runValidateConfig returned error: %v", err)
+	}
+
+	output := out.String()
+	if !strings.Contains(output, "valid MCPJungle config") {
+		t.Fatalf("expected success output, got: %s", output)
+	}
+	if !strings.Contains(output, "mcp-server") {
+		t.Fatalf("expected detected config type in output, got: %s", output)
+	}
+}
+
+func writeValidateTestConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "validate-config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp config: %v", err)
+	}
+	if _, err := file.WriteString(contents); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close temp config: %v", err)
+	}
+	return file.Name()
+}

--- a/docs/reference/config-file.mdx
+++ b/docs/reference/config-file.mdx
@@ -65,6 +65,24 @@ For the enterprise bootstrap flow and login workflow, see [Enterprise operations
 
 Several `mcpjungle` commands accept a `-c` / `--conf` flag pointing to a JSON file instead of inline CLI flags. This section documents every supported JSON format.
 
+### Validate a JSON config file
+
+Run `mcpjungle validate <file>` before using a JSON config file with `register` or `create` commands:
+
+```bash
+mcpjungle validate ./my_server.json
+mcpjungle validate ./my_tool_group.json
+mcpjungle validate ./new_mcp_client.json
+```
+
+The command infers whether the file is an MCP server, tool group, MCP client, or user config. For ambiguous files, pass an explicit type:
+
+```bash
+mcpjungle validate --type mcp-client ./new_mcp_client.json
+```
+
+The validation is static. It checks JSON syntax, required fields, supported transport and session-mode values, URL shape, environment-variable placeholders, and token references. It does not connect to the configured MCP server or check whether referenced servers, tools, clients, or users already exist.
+
 ### `${VAR_NAME}` placeholder substitution
 
 All JSON config files support environment variable placeholders in string fields. Before sending the request to the server, the CLI expands every `${VAR_NAME}` occurrence using the current shell environment.

--- a/internal/service/configvalidation/configvalidation.go
+++ b/internal/service/configvalidation/configvalidation.go
@@ -1,0 +1,343 @@
+// Package configvalidation validates MCPJungle JSON configuration files without
+// requiring a running MCPJungle server.
+package configvalidation
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+
+	"github.com/mcpjungle/mcpjungle/internal"
+	"github.com/mcpjungle/mcpjungle/internal/configresolver"
+	"github.com/mcpjungle/mcpjungle/pkg/types"
+)
+
+// ConfigType identifies a supported MCPJungle JSON configuration shape.
+type ConfigType string
+
+const (
+	// ConfigTypeMCPServer is used with `mcpjungle register --conf`.
+	ConfigTypeMCPServer ConfigType = "mcp-server"
+	// ConfigTypeToolGroup is used with `mcpjungle create group --conf`.
+	ConfigTypeToolGroup ConfigType = "tool-group"
+	// ConfigTypeMCPClient is used with `mcpjungle create mcp-client --conf`.
+	ConfigTypeMCPClient ConfigType = "mcp-client"
+	// ConfigTypeUser is used with `mcpjungle create user --conf`.
+	ConfigTypeUser ConfigType = "user"
+)
+
+// Result describes a successful validation.
+type Result struct {
+	Type ConfigType
+}
+
+type validator struct {
+	configType ConfigType
+	matches    func(map[string]json.RawMessage) bool
+	validate   func([]byte) error
+}
+
+var validators = []validator{
+	{configType: ConfigTypeMCPServer, matches: looksLikeMCPServerConfig, validate: validateMCPServerConfig},
+	{configType: ConfigTypeToolGroup, matches: looksLikeToolGroupConfig, validate: validateToolGroupConfig},
+	{configType: ConfigTypeMCPClient, matches: looksLikeMCPClientConfig, validate: validateMCPClientConfig},
+	{configType: ConfigTypeUser, matches: looksLikeUserConfig, validate: validateUserConfig},
+}
+
+var (
+	validServerName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+	validGroupName  = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_-]*$`)
+)
+
+// ValidateFile reads and validates a JSON config file, inferring the config type.
+func ValidateFile(filePath string) (*Result, error) {
+	return ValidateFileAs(filePath, "")
+}
+
+// ValidateFileAs reads and validates a JSON config file as the requested type.
+func ValidateFileAs(filePath string, configType ConfigType) (*Result, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read config file %s: %w", filePath, err)
+	}
+	result, err := ValidateBytesAs(data, configType)
+	if err != nil {
+		return nil, fmt.Errorf("invalid config file %s: %w", filePath, err)
+	}
+	return result, nil
+}
+
+// ValidateBytes validates a JSON config document, inferring the config type.
+func ValidateBytes(data []byte) (*Result, error) {
+	return ValidateBytesAs(data, "")
+}
+
+// ValidateBytesAs validates a JSON config document as the requested type.
+func ValidateBytesAs(data []byte, configType ConfigType) (*Result, error) {
+	raw, err := parseConfigObject(data)
+	if err != nil {
+		return nil, err
+	}
+
+	if configType != "" {
+		for _, v := range validators {
+			if v.configType != configType {
+				continue
+			}
+			if err := v.validate(data); err != nil {
+				return nil, err
+			}
+			return &Result{Type: configType}, nil
+		}
+		return nil, fmt.Errorf("unsupported config type %q", configType)
+	}
+
+	for _, v := range validators {
+		if !v.matches(raw) {
+			continue
+		}
+		if err := v.validate(data); err != nil {
+			return nil, err
+		}
+		return &Result{Type: v.configType}, nil
+	}
+
+	return nil, fmt.Errorf(
+		"config does not match any supported MCPJungle config type: %s",
+		supportedConfigTypes(),
+	)
+}
+
+func parseConfigObject(data []byte) (map[string]json.RawMessage, error) {
+	if strings.TrimSpace(string(data)) == "" {
+		return nil, fmt.Errorf("config file is empty")
+	}
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse JSON config: %w", err)
+	}
+	if raw == nil {
+		return nil, fmt.Errorf("config must be a JSON object")
+	}
+	return raw, nil
+}
+
+func looksLikeMCPServerConfig(raw map[string]json.RawMessage) bool {
+	return hasAnyKey(raw,
+		"transport",
+		"url",
+		"command",
+		"args",
+		"env",
+		"bearer_token",
+		"headers",
+		"session_mode",
+		"oauth_redirect_uri",
+		"oauth_client_id",
+		"oauth_client_secret",
+		"oauth_scopes",
+	)
+}
+
+func looksLikeToolGroupConfig(raw map[string]json.RawMessage) bool {
+	return hasAnyKey(raw, "included_tools", "included_servers", "excluded_tools")
+}
+
+func looksLikeMCPClientConfig(raw map[string]json.RawMessage) bool {
+	return hasAnyKey(raw, "allowed_servers")
+}
+
+func looksLikeUserConfig(raw map[string]json.RawMessage) bool {
+	return hasAnyKey(raw, "access_token", "access_token_ref")
+}
+
+func validateMCPServerConfig(data []byte) error {
+	var input types.RegisterServerInput
+	if err := unmarshalAndResolve(data, &input); err != nil {
+		return err
+	}
+	if err := validateServerName(input.Name); err != nil {
+		return err
+	}
+	transport, err := types.ValidateTransport(input.Transport)
+	if err != nil {
+		return err
+	}
+	if _, err := types.ValidateSessionMode(input.SessionMode); err != nil {
+		return err
+	}
+
+	switch transport {
+	case types.TransportStreamableHTTP, types.TransportSSE:
+		if err := validateHTTPURL(input.URL); err != nil {
+			return err
+		}
+	case types.TransportStdio:
+		if strings.TrimSpace(input.Command) == "" {
+			return fmt.Errorf("command is required for stdio transport")
+		}
+	}
+
+	return nil
+}
+
+func validateToolGroupConfig(data []byte) error {
+	var group types.ToolGroup
+	if err := unmarshalAndResolve(data, &group); err != nil {
+		return err
+	}
+	if strings.TrimSpace(group.Name) == "" {
+		return fmt.Errorf("tool group name cannot be empty")
+	}
+	if !validGroupName.MatchString(group.Name) {
+		return fmt.Errorf("invalid group name: must start with an alphanumeric character and can only contain alphanumeric characters, underscores, and hyphens")
+	}
+	if len(group.IncludedTools) == 0 && len(group.IncludedServers) == 0 {
+		return fmt.Errorf("tool group config must define included_tools or included_servers")
+	}
+	if err := validateNonEmptyStrings("included_tools", group.IncludedTools); err != nil {
+		return err
+	}
+	if err := validateNonEmptyStrings("included_servers", group.IncludedServers); err != nil {
+		return err
+	}
+	return validateNonEmptyStrings("excluded_tools", group.ExcludedTools)
+}
+
+func validateMCPClientConfig(data []byte) error {
+	var client types.McpClientConfig
+	if err := unmarshalAndResolve(data, &client); err != nil {
+		return err
+	}
+	if strings.TrimSpace(client.Name) == "" {
+		return fmt.Errorf("MCP client config must define a client name")
+	}
+	if err := validateNonEmptyStrings("allowed_servers", client.AllowMcpServers); err != nil {
+		return err
+	}
+	return validateAccessTokenConfig("MCP client", client.AccessToken, client.AccessTokenRef)
+}
+
+func validateUserConfig(data []byte) error {
+	var user types.UserConfig
+	if err := unmarshalAndResolve(data, &user); err != nil {
+		return err
+	}
+	if strings.TrimSpace(user.Username) == "" {
+		return fmt.Errorf("user config must define a username")
+	}
+	return validateAccessTokenConfig("user", user.AccessToken, user.AccessTokenRef)
+}
+
+func unmarshalAndResolve(data []byte, target any) error {
+	if err := json.Unmarshal(data, target); err != nil {
+		return fmt.Errorf("failed to parse config file: %w", err)
+	}
+	if err := configresolver.ResolveEnvVars(target); err != nil {
+		return fmt.Errorf("failed to resolve config file environment variables: %w", err)
+	}
+	return nil
+}
+
+func validateAccessTokenConfig(label, token string, ref types.AccessTokenRef) error {
+	resolved, err := resolveAccessToken(token, ref)
+	if err != nil {
+		return err
+	}
+	if resolved == "" {
+		return fmt.Errorf("%s config must supply a custom access token", label)
+	}
+	if err := internal.ValidateAccessToken(resolved); err != nil {
+		return fmt.Errorf("invalid access token: %v", err)
+	}
+	return nil
+}
+
+func resolveAccessToken(token string, ref types.AccessTokenRef) (string, error) {
+	if token != "" {
+		return token, nil
+	}
+	if ref.Env != "" {
+		value, ok := os.LookupEnv(ref.Env)
+		if ok {
+			trimmed := strings.TrimSpace(value)
+			if trimmed != "" {
+				return trimmed, nil
+			}
+		}
+		if ref.File == "" {
+			return "", fmt.Errorf("environment variable %s is not set or empty", ref.Env)
+		}
+	}
+	if ref.File != "" {
+		data, err := os.ReadFile(ref.File)
+		if err != nil {
+			return "", fmt.Errorf("failed to read access token file %s: %w", ref.File, err)
+		}
+		trimmed := strings.TrimSpace(string(data))
+		if trimmed == "" {
+			return "", fmt.Errorf("access token file %s is empty", ref.File)
+		}
+		return trimmed, nil
+	}
+	return "", nil
+}
+
+func validateServerName(name string) error {
+	if name == "" {
+		return fmt.Errorf("invalid server name: must not be empty")
+	}
+	if !validServerName.MatchString(name) {
+		return fmt.Errorf("invalid server name: must only contain alphanumeric characters, underscores, and hyphens")
+	}
+	if strings.Contains(name, "__") {
+		return fmt.Errorf("invalid server name: must not contain multiple consecutive underscores")
+	}
+	if strings.HasSuffix(name, "_") {
+		return fmt.Errorf("invalid server name: must not end with an underscore")
+	}
+	return nil
+}
+
+func validateHTTPURL(rawURL string) error {
+	u, err := url.Parse(rawURL)
+	if err != nil || u.Host == "" {
+		return fmt.Errorf("invalid url: %q must be a valid http or https url", rawURL)
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return nil
+	default:
+		return fmt.Errorf("invalid url: %q must be a valid http or https url", rawURL)
+	}
+}
+
+func validateNonEmptyStrings(field string, values []string) error {
+	for i, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return fmt.Errorf("%s[%d] cannot be empty", field, i)
+		}
+	}
+	return nil
+}
+
+func hasAnyKey(raw map[string]json.RawMessage, keys ...string) bool {
+	for _, key := range keys {
+		if _, ok := raw[key]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func supportedConfigTypes() string {
+	types := make([]string, 0, len(validators))
+	for _, v := range validators {
+		types = append(types, string(v.configType))
+	}
+	return strings.Join(types, ", ")
+}

--- a/internal/service/configvalidation/configvalidation_test.go
+++ b/internal/service/configvalidation/configvalidation_test.go
@@ -1,0 +1,118 @@
+package configvalidation
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestValidateFileDetectsMCPServerConfig(t *testing.T) {
+	t.Parallel()
+
+	file := writeTempConfig(t, `{
+		"name": "context7",
+		"transport": "streamable_http",
+		"url": "https://mcp.context7.com/mcp"
+	}`)
+
+	result, err := ValidateFile(file)
+	if err != nil {
+		t.Fatalf("ValidateFile returned error: %v", err)
+	}
+	if result.Type != ConfigTypeMCPServer {
+		t.Fatalf("expected config type %q, got %q", ConfigTypeMCPServer, result.Type)
+	}
+}
+
+func TestValidateFileRejectsInvalidMCPServerURL(t *testing.T) {
+	t.Parallel()
+
+	file := writeTempConfig(t, `{
+		"name": "bad-server",
+		"transport": "streamable_http",
+		"url": "not-a-url"
+	}`)
+
+	_, err := ValidateFile(file)
+	if err == nil {
+		t.Fatal("expected invalid URL error")
+	}
+	if !strings.Contains(err.Error(), "valid http or https url") {
+		t.Fatalf("expected URL validation error, got: %v", err)
+	}
+}
+
+func TestValidateBytesDetectsToolGroupConfig(t *testing.T) {
+	t.Parallel()
+
+	result, err := ValidateBytes([]byte(`{
+		"name": "coding-tools",
+		"included_servers": ["github"],
+		"excluded_tools": ["github__delete_repository"]
+	}`))
+	if err != nil {
+		t.Fatalf("ValidateBytes returned error: %v", err)
+	}
+	if result.Type != ConfigTypeToolGroup {
+		t.Fatalf("expected config type %q, got %q", ConfigTypeToolGroup, result.Type)
+	}
+}
+
+func TestValidateBytesDetectsMCPClientConfig(t *testing.T) {
+	t.Parallel()
+
+	result, err := ValidateBytes([]byte(`{
+		"name": "cursor-local",
+		"allowed_servers": ["context7"],
+		"access_token": "client-token"
+	}`))
+	if err != nil {
+		t.Fatalf("ValidateBytes returned error: %v", err)
+	}
+	if result.Type != ConfigTypeMCPClient {
+		t.Fatalf("expected config type %q, got %q", ConfigTypeMCPClient, result.Type)
+	}
+}
+
+func TestValidateBytesDetectsUserConfig(t *testing.T) {
+	t.Parallel()
+
+	result, err := ValidateBytes([]byte(`{
+		"name": "alice",
+		"access_token": "alice-token"
+	}`))
+	if err != nil {
+		t.Fatalf("ValidateBytes returned error: %v", err)
+	}
+	if result.Type != ConfigTypeUser {
+		t.Fatalf("expected config type %q, got %q", ConfigTypeUser, result.Type)
+	}
+}
+
+func TestValidateBytesRejectsUnknownConfig(t *testing.T) {
+	t.Parallel()
+
+	_, err := ValidateBytes([]byte(`{"name": "incomplete"}`))
+	if err == nil {
+		t.Fatal("expected unknown config error")
+	}
+	if !strings.Contains(err.Error(), "does not match any supported MCPJungle config type") {
+		t.Fatalf("expected unknown config error, got: %v", err)
+	}
+}
+
+func writeTempConfig(t *testing.T, contents string) string {
+	t.Helper()
+
+	file, err := os.CreateTemp(t.TempDir(), "mcpjungle-config-*.json")
+	if err != nil {
+		t.Fatalf("failed to create temp config: %v", err)
+	}
+	if _, err := file.WriteString(contents); err != nil {
+		t.Fatalf("failed to write temp config: %v", err)
+	}
+	if err := file.Close(); err != nil {
+		t.Fatalf("failed to close temp config: %v", err)
+	}
+	return file.Name()
+}


### PR DESCRIPTION
## Summary

Adds a local `mcpjungle validate <file>` CLI entry point for JSON config files users plan to pass to `register` or `create` commands.

- Adds reusable server-side validation logic in `internal/service/configvalidation`.
- Infers supported config types from fields: MCP server, tool group, MCP client, and user.
- Supports `--type mcp-server|tool-group|mcp-client|user` for ambiguous files.
- Documents the validation command in the config file reference.

Boundary: this MVP performs static validation only. It checks JSON shape, required fields, transport/session-mode values, URL syntax, environment placeholders, and token references. It does not connect to an MCP server or check whether referenced servers, tools, clients, or users already exist.

## Pre-Agreement Checklist (required)

Please check all boxes before requesting review:

- [x] I have read and followed the [contribution guidelines](https://docs.mcpjungle.com/developers/contributing).
- [x] This PR addresses an existing issue or a concluded discussion.
- [x] If there was no existing issue/discussion, I opened one first to align with maintainers before submitting this PR.
- [x] I confirmed the issue/discussion priority with maintainers and understand low-priority items may receive limited attention.
- [x] I kept this PR focused and reasonably small; if the work is large, I split it into smaller PRs where possible.
- [ ] Any AI-generated code in this PR was reviewed by a human author.

## Validation Checklist

- [ ] `go test ./...` passes locally.
- [ ] `scripts/test-mcpjungle.sh` passes locally.
- [x] I added or updated tests for new behavior where applicable.
- [x] I updated documentation for user-facing changes where applicable.

Validation run locally:

- [x] `go test ./internal/service/configvalidation -count=1`
- [x] `go test ./cmd -run 'TestValidate|TestRunValidateConfig' -count=1`
- [x] `go run . validate <temp-json>`
- [x] `git diff --cached --check`

Local blockers for broader validation:

- `go test -cover ./...` does not pass in this Windows environment. With default `CGO_ENABLED=0`, packages that use `go-sqlite3` fail with `Binary was compiled with 'CGO_ENABLED=0', go-sqlite3 requires cgo to work`; with `CGO_ENABLED=1`, the run fails because `gcc` is not installed. The same run also shows existing Windows/environment-sensitive failures in `cmd/export_test.go` and `cmd/config/config_test.go`.
- `bash scripts/test-mcpjungle.sh` exits before running tests because this checkout has CRLF line endings for the shell script in this Windows environment (`set: pipefail\r: invalid option name`).

## Linked Context

- Issue(s): Closes #247
- Discussion(s): n/a