### PR TITLE
fix: tolerant tool-group resolution keeps valid tools instead of emptying the group on startup

### DIFF
--- a/internal/model/tool_group.go
+++ b/internal/model/tool_group.go
@@ -112,3 +112,65 @@ func (g *ToolGroup) ResolveEffectiveTools(mcpService ToolResolver) ([]string, er
 
 	return result, nil
 }
+
+// ResolveEffectiveToolsTolerant resolves the effective tools for this group like
+// ResolveEffectiveTools, but tolerates included servers that can no longer be resolved.
+//
+// Instead of returning early when ListToolsByServer fails for an included server, it
+// records that server name in skipped and continues resolving the remaining servers and
+// the explicit included/excluded tools. This is intended for startup rehydration, where
+// a referenced MCP server may have been deregistered: the group should still expose every
+// tool that still resolves rather than being emptied entirely.
+//
+// The returned skipped slice lists the included servers that could not be resolved, so the
+// caller can emit a clear warning. err is only non-nil for unmarshalling failures of the
+// group's own JSON fields, which indicate a corrupt record rather than a missing reference.
+//
+// Tool exclusions are applied last, mirroring ResolveEffectiveTools.
+func (g *ToolGroup) ResolveEffectiveToolsTolerant(mcpService ToolResolver) (tools []string, skipped []string, err error) {
+	effectiveTools := make(map[string]bool)
+
+	// Add tools from included_tools
+	includedTools, err := g.GetTools()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get included tools: %w", err)
+	}
+	for _, tool := range includedTools {
+		effectiveTools[tool] = true
+	}
+
+	// Add tools from included_servers, skipping any server that fails to resolve.
+	includedServers, err := g.GetServers()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get included servers: %w", err)
+	}
+	for _, serverName := range includedServers {
+		serverTools, err := mcpService.ListToolsByServer(serverName)
+		if err != nil {
+			// The server can no longer be resolved (e.g. it was deregistered).
+			// Skip it instead of discarding the whole group.
+			skipped = append(skipped, serverName)
+			continue
+		}
+		for _, tool := range serverTools {
+			effectiveTools[tool.Name] = true
+		}
+	}
+
+	// Remove tools from excluded_tools
+	excludedTools, err := g.GetExcludedTools()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get excluded tools: %w", err)
+	}
+	for _, tool := range excludedTools {
+		delete(effectiveTools, tool)
+	}
+
+	// Convert map to slice
+	result := make([]string, 0, len(effectiveTools))
+	for tool := range effectiveTools {
+		result = append(result, tool)
+	}
+
+	return result, skipped, nil
+}

--- a/internal/model/tool_group_test.go
+++ b/internal/model/tool_group_test.go
@@ -2,6 +2,7 @@ package model
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"gorm.io/datatypes"
@@ -17,6 +18,20 @@ func (m *mockToolResolver) ListToolsByServer(serverName string) ([]Tool, error) 
 		return tools, nil
 	}
 	return []Tool{}, nil
+}
+
+// errorToolResolver implements ToolResolver for testing the tolerant resolver.
+// It returns the configured tools for known servers and an error for any other
+// server name, simulating a server that has been deregistered.
+type errorToolResolver struct {
+	serverTools map[string][]Tool
+}
+
+func (m *errorToolResolver) ListToolsByServer(serverName string) ([]Tool, error) {
+	if tools, exists := m.serverTools[serverName]; exists {
+		return tools, nil
+	}
+	return nil, fmt.Errorf("server %s not found", serverName)
 }
 
 func TestToolGroup_GetTools(t *testing.T) {
@@ -265,6 +280,141 @@ func TestToolGroup_ResolveEffectiveTools(t *testing.T) {
 
 		if result[0] != "manual__tool1" {
 			t.Errorf("Expected manual__tool1, got %v", result)
+		}
+	})
+}
+
+func TestToolGroup_ResolveEffectiveToolsTolerant(t *testing.T) {
+	resolver := &errorToolResolver{
+		serverTools: map[string][]Tool{
+			"time": {
+				{Name: "time__get_current_time"},
+				{Name: "time__convert_time"},
+			},
+			"deepwiki": {
+				{Name: "deepwiki__read_wiki_contents"},
+				{Name: "deepwiki__search_wiki"},
+			},
+		},
+	}
+
+	t.Run("One server missing keeps the surviving server's tools", func(t *testing.T) {
+		servers := []string{"time", "missing"}
+		serversJSON, _ := json.Marshal(servers)
+
+		group := &ToolGroup{
+			IncludedServers: datatypes.JSON(serversJSON),
+		}
+
+		result, skipped, err := group.ResolveEffectiveToolsTolerant(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectiveToolsTolerant() failed: %v", err)
+		}
+
+		if len(result) != 2 {
+			t.Errorf("Expected 2 tools from time server, got %d (%v)", len(result), result)
+		}
+
+		toolMap := make(map[string]bool)
+		for _, tool := range result {
+			toolMap[tool] = true
+		}
+		if !toolMap["time__get_current_time"] || !toolMap["time__convert_time"] {
+			t.Errorf("Expected time tools, got %v", result)
+		}
+
+		if len(skipped) != 1 || skipped[0] != "missing" {
+			t.Errorf("Expected skipped=[missing], got %v", skipped)
+		}
+	})
+
+	t.Run("All servers missing yields empty tools and lists all skipped", func(t *testing.T) {
+		servers := []string{"missing1", "missing2"}
+		serversJSON, _ := json.Marshal(servers)
+
+		group := &ToolGroup{
+			IncludedServers: datatypes.JSON(serversJSON),
+		}
+
+		result, skipped, err := group.ResolveEffectiveToolsTolerant(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectiveToolsTolerant() failed: %v", err)
+		}
+
+		if len(result) != 0 {
+			t.Errorf("Expected 0 tools when all servers are missing, got %d (%v)", len(result), result)
+		}
+
+		if len(skipped) != 2 {
+			t.Errorf("Expected 2 skipped servers, got %d (%v)", len(skipped), skipped)
+		}
+	})
+
+	t.Run("All servers valid matches strict resolver and reports no skips", func(t *testing.T) {
+		servers := []string{"time", "deepwiki"}
+		serversJSON, _ := json.Marshal(servers)
+
+		group := &ToolGroup{
+			IncludedServers: datatypes.JSON(serversJSON),
+		}
+
+		tolerant, skipped, err := group.ResolveEffectiveToolsTolerant(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectiveToolsTolerant() failed: %v", err)
+		}
+		if len(skipped) != 0 {
+			t.Errorf("Expected no skipped servers, got %v", skipped)
+		}
+
+		strict, err := group.ResolveEffectiveTools(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectiveTools() failed: %v", err)
+		}
+
+		if len(tolerant) != len(strict) {
+			t.Errorf("Expected tolerant result (%d) to match strict result (%d)", len(tolerant), len(strict))
+		}
+
+		strictMap := make(map[string]bool)
+		for _, tool := range strict {
+			strictMap[tool] = true
+		}
+		for _, tool := range tolerant {
+			if !strictMap[tool] {
+				t.Errorf("Tolerant result contains tool %s not present in strict result %v", tool, strict)
+			}
+		}
+	})
+
+	t.Run("Excluded tools are still applied", func(t *testing.T) {
+		servers := []string{"time", "missing"}
+		serversJSON, _ := json.Marshal(servers)
+
+		excluded := []string{"time__convert_time"}
+		excludedJSON, _ := json.Marshal(excluded)
+
+		group := &ToolGroup{
+			IncludedServers: datatypes.JSON(serversJSON),
+			ExcludedTools:   datatypes.JSON(excludedJSON),
+		}
+
+		result, skipped, err := group.ResolveEffectiveToolsTolerant(resolver)
+		if err != nil {
+			t.Fatalf("ResolveEffectiveToolsTolerant() failed: %v", err)
+		}
+
+		toolMap := make(map[string]bool)
+		for _, tool := range result {
+			toolMap[tool] = true
+		}
+		if !toolMap["time__get_current_time"] {
+			t.Errorf("Expected time__get_current_time in result %v", result)
+		}
+		if toolMap["time__convert_time"] {
+			t.Errorf("Expected excluded tool time__convert_time to be absent from result %v", result)
+		}
+		if len(skipped) != 1 || skipped[0] != "missing" {
+			t.Errorf("Expected skipped=[missing], got %v", skipped)
 		}
 	})
 }

--- a/internal/service/toolgroup/toolgroup.go
+++ b/internal/service/toolgroup/toolgroup.go
@@ -366,13 +366,15 @@ func (s *ToolGroupService) initToolGroupMCPServers() error {
 		mcpServer := s.newMCPServer(group.Name)
 		sseMcpServer := s.newSseMCPServer(group.Name)
 
-		toolNames, err := group.ResolveEffectiveTools(s.mcpService)
+		// Use the tolerant resolver during startup rehydration. If a referenced server can no
+		// longer be resolved (e.g. it was deregistered), we still want to expose every tool that
+		// resolves rather than emptying the whole group. Authoring flows (create/update group)
+		// keep using the strict ResolveEffectiveTools so invalid references fail fast.
+		toolNames, skipped, err := group.ResolveEffectiveToolsTolerant(s.mcpService)
 		if err != nil {
-			// If resolution of any server or specific tool fails for a group, the error is logged and
-			// the group is added as an empty MCP server to the proxy.
-			// This is not ideal, but it ensures that mcpjungle server startup doesn't fail.
-			// TODO: Change design to include all other servers & tools that were resolved.
-			// See https://github.com/mcpjungle/MCPJungle/issues/233
+			// A non-nil error here means the group's own record is corrupt (its JSON fields could
+			// not be unmarshalled), not just a missing reference. The group is initialized as an
+			// empty MCP server so that mcpjungle server startup doesn't fail.
 			log.Printf(
 				"[ERROR] failed to resolve effective tools for tool group %s during startup; the tool group will be initialized as empty: %v",
 				group.Name,
@@ -382,7 +384,19 @@ func (s *ToolGroupService) initToolGroupMCPServers() error {
 			s.addToolGroupSseMCPServer(group.Name, sseMcpServer)
 			continue
 		}
-		// TODO: Log a warning if a group has no tools, ie, len(toolNames) == 0
+		if len(skipped) > 0 {
+			log.Printf(
+				"[WARN] tool group %s references servers that could not be resolved during startup and were skipped: %v; the group will be initialized with its remaining tools",
+				group.Name,
+				skipped,
+			)
+		}
+		if len(toolNames) == 0 {
+			log.Printf(
+				"[WARN] tool group %s resolved to zero tools during startup and will be initialized as empty",
+				group.Name,
+			)
+		}
 
 		for _, name := range toolNames {
 			tool, exists := s.mcpService.GetToolInstance(name)

--- a/internal/service/toolgroup/toolgroup_test.go
+++ b/internal/service/toolgroup/toolgroup_test.go
@@ -334,6 +334,59 @@ func TestNewToolGroupService_DegradedPersistedGroupDoesNotFailStartup(t *testing
 	}
 }
 
+func TestNewToolGroupService_PartialResolutionKeepsValidTools(t *testing.T) {
+	db := setupInMemoryDB(t)
+
+	validServer, err := model.NewStdioServer("valid-server", "Valid server", "echo", nil, nil, "")
+	if err != nil {
+		t.Fatalf("failed to create valid server model: %v", err)
+	}
+	if err := db.Create(validServer).Error; err != nil {
+		t.Fatalf("failed to persist valid server: %v", err)
+	}
+
+	validTool := model.Tool{
+		ServerID:    validServer.ID,
+		Name:        "sum",
+		Description: "adds numbers",
+		InputSchema: []byte(`{"type":"object"}`),
+		Enabled:     true,
+	}
+	if err := db.Create(&validTool).Error; err != nil {
+		t.Fatalf("failed to persist valid tool: %v", err)
+	}
+
+	// This group references one server that still resolves and one that is missing.
+	// The missing server must be skipped while the valid server's tools are preserved,
+	// rather than the whole group being emptied (issue #233).
+	partialGroup := model.ToolGroup{
+		Name:            "partial-group",
+		IncludedServers: datatypes.JSON([]byte(`["valid-server","missing-server"]`)),
+	}
+	if err := db.Create(&partialGroup).Error; err != nil {
+		t.Fatalf("failed to persist partial group: %v", err)
+	}
+
+	mcpService := newTestMCPService(t, db)
+
+	svc, err := NewToolGroupService(db, mcpService)
+	if err != nil {
+		t.Fatalf("expected partial resolution not to fail startup, got: %v", err)
+	}
+
+	proxy, ok := svc.GetToolGroupMCPServer("partial-group")
+	if !ok {
+		t.Fatal("expected partial group MCP proxy to be initialized")
+	}
+	tools := proxy.ListTools()
+	if len(tools) != 1 {
+		t.Fatalf("expected partial group proxy to expose 1 surviving tool, got %d", len(tools))
+	}
+	if _, ok := tools["valid-server__sum"]; !ok {
+		t.Fatalf("expected partial group proxy to expose valid-server__sum, got keys %v", reflect.ValueOf(tools).MapKeys())
+	}
+}
+
 func TestCreateToolGroup_InvalidIncludedServerStillFailsFast(t *testing.T) {
 	db := setupInMemoryDB(t)
 	s := &ToolGroupService{


### PR DESCRIPTION
## Summary

When an MCP server referenced by a tool group is deregistered and mcpjungle is restarted, the group used to be initialized as an empty proxy if resolving *any* included server failed - discarding every tool that still resolved fine. This PR makes startup rehydration tolerant: a group now keeps the tools from every server that still resolves and only skips the missing ones, emitting a clear warning about what was skipped.

This is the follow-up the maintainer spec'd in #233 and flagged with the `TODO` in `initToolGroupMCPServers`. A new model method `ResolveEffectiveToolsTolerant` mirrors `ResolveEffectiveTools` but records unresolvable servers in a `skipped` slice and continues instead of returning early. The startup loop uses it, only falling back to an empty group when zero tools remain. The strict `ResolveEffectiveTools` is left untouched, so `create`/`update` group authoring flows still fail fast on invalid references. The resolved `TODO` comment referencing #233 is removed.

## Pre-Agreement Checklist (required)

Please check all boxes before requesting review:

- [x] I have read and followed the [contribution guidelines](https://docs.mcpjungle.com/developers/contributing).
- [x] This PR addresses an existing issue or a concluded discussion.
- [x] If there was no existing issue/discussion, I opened one first to align with maintainers before submitting this PR.
- [x] I confirmed the issue/discussion priority with maintainers and understand low-priority items may receive limited attention.
- [x] I kept this PR focused and reasonably small; if the work is large, I split it into smaller PRs where possible.
- [x] Any AI-generated code in this PR was reviewed by a human author.

## Validation Checklist

- [x] `go test ./...` passes locally.
- [ ] `scripts/test-mcpjungle.sh` passes locally.
- [x] I added or updated tests for new behavior where applicable.
- [ ] I updated documentation for user-facing changes where applicable.

## Linked Context

- Issue(s): #233
- Discussion(s):

Fixes #233
