### PR TITLE
feat: honor HTTP(S)_PROXY/NO_PROXY for upstream MCP connections

### DIFF
--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -178,6 +178,42 @@ When the server starts it resolves the database connection in this order:
 
 ---
 
+## Proxies
+
+MCPJungle honors Go's standard proxy environment variables for outbound HTTP(S) requests. The uppercase names below and their lowercase forms are supported.
+
+<ParamField path="HTTP_PROXY" type="string">
+  Proxy URL for outbound plain HTTP requests.
+
+  ```bash
+  export HTTP_PROXY=http://proxy.example.com:8080
+  ```
+
+  For the CLI, this applies to HTTP requests from `mcpjungle` commands to the MCPJungle server. For the server, this applies to HTTP upstream MCP connections, including upstream OAuth metadata discovery, dynamic client registration, and token exchange requests made over HTTP.
+</ParamField>
+
+<ParamField path="HTTPS_PROXY" type="string">
+  Proxy URL for outbound HTTPS requests.
+
+  ```bash
+  export HTTPS_PROXY=http://proxy.example.com:8080
+  ```
+
+  For the CLI, this applies to HTTPS requests from `mcpjungle` commands to the MCPJungle server. For the server, this applies to HTTPS upstream MCP connections, including upstream OAuth metadata discovery, dynamic client registration, and token exchange requests made over HTTPS.
+</ParamField>
+
+<ParamField path="NO_PROXY" type="string">
+  Comma-separated hosts, domains, IP addresses, or CIDR ranges that should bypass `HTTP_PROXY` and `HTTPS_PROXY`.
+
+  ```bash
+  export NO_PROXY=localhost,127.0.0.1,.internal.example.com
+  ```
+
+  Use this for MCPJungle server hosts or upstream MCP hosts that must be reached directly.
+</ParamField>
+
+---
+
 ## Docker
 
 <ParamField path="MCPJUNGLE_IMAGE_TAG" type="string">
@@ -217,4 +253,7 @@ When the server starts it resolves the database connection in this order:
 | `OTEL_ENABLED` | Observability | mode-dependent | Enable OpenTelemetry metrics. |
 | `OTEL_RESOURCE_ATTRIBUTES` | Observability | — | Additional OTel resource attributes. |
 | `SESSION_IDLE_TIMEOUT_SEC` | Connections | `-1` | Idle timeout for stateful sessions. |
+| `HTTP_PROXY` | Proxies | — | Proxy for outbound HTTP requests from the CLI and server. |
+| `HTTPS_PROXY` | Proxies | — | Proxy for outbound HTTPS requests from the CLI and server. |
+| `NO_PROXY` | Proxies | — | Hosts, domains, IPs, or CIDR ranges that bypass configured proxies. |
 | `MCPJUNGLE_IMAGE_TAG` | Docker | `latest` | Docker image tag for Compose deployments. |

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	go.opentelemetry.io/otel/sdk v1.38.0
 	go.opentelemetry.io/otel/sdk/metric v1.38.0
 	go.uber.org/zap v1.27.0
+	golang.org/x/net v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 	gorm.io/datatypes v1.2.5
 	gorm.io/driver/postgres v1.5.11
@@ -79,7 +80,6 @@ require (
 	go.uber.org/multierr v1.10.0 // indirect
 	golang.org/x/arch v0.20.0 // indirect
 	golang.org/x/crypto v0.41.0 // indirect
-	golang.org/x/net v0.43.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 	golang.org/x/sys v0.35.0 // indirect
 	golang.org/x/text v0.28.0 // indirect

--- a/internal/service/mcp/upstream_oauth.go
+++ b/internal/service/mcp/upstream_oauth.go
@@ -193,6 +193,7 @@ func prepareOAuthConfig(input *types.RegisterServerInput, tokenStore mcpgotransp
 		Scopes:       input.OAuthScopes,
 		TokenStore:   tokenStore,
 		PKCEEnabled:  true,
+		HTTPClient:   proxyAwareHTTPClient(),
 	}
 }
 
@@ -267,7 +268,8 @@ func (m *MCPService) bootstrapUpstreamOAuth(ctx context.Context, input *types.Re
 		if err != nil {
 			return err
 		}
-		c, err := mcpgoclient.NewOAuthSSEClient(conf.URL, prepareOAuthConfig(input, mcpgoclient.NewMemoryTokenStore()))
+		opts := []mcpgotransport.ClientOption{mcpgotransport.WithHTTPClient(proxyAwareHTTPClient())}
+		c, err := mcpgoclient.NewOAuthSSEClient(conf.URL, prepareOAuthConfig(input, mcpgoclient.NewMemoryTokenStore()), opts...)
 		if err != nil {
 			return fmt.Errorf("failed to create OAuth SSE client for MCP server: %w", err)
 		}
@@ -404,7 +406,8 @@ func (m *MCPService) buildOAuthHandlerForRegisteredClient(ctx context.Context, s
 		if err != nil {
 			return nil, err
 		}
-		c, err := mcpgoclient.NewOAuthSSEClient(conf.URL, prepareOAuthConfig(input, mcpgoclient.NewMemoryTokenStore()))
+		opts := []mcpgotransport.ClientOption{mcpgotransport.WithHTTPClient(proxyAwareHTTPClient())}
+		c, err := mcpgoclient.NewOAuthSSEClient(conf.URL, prepareOAuthConfig(input, mcpgoclient.NewMemoryTokenStore()), opts...)
 		if err != nil {
 			return nil, err
 		}
@@ -470,7 +473,7 @@ func registerOAuthClientWithoutEmptyScope(
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := proxyAwareHTTPClient().Do(req)
 	if err != nil {
 		return "", "", fmt.Errorf("failed to send registration request: %w", err)
 	}
@@ -675,7 +678,8 @@ func (m *MCPService) processOAuthAuthorizationCode(ctx context.Context, server *
 		if err != nil {
 			return err
 		}
-		c, err := mcpgoclient.NewOAuthSSEClient(conf.URL, prepareOAuthConfig(input, tokenStore))
+		opts := []mcpgotransport.ClientOption{mcpgotransport.WithHTTPClient(proxyAwareHTTPClient())}
+		c, err := mcpgoclient.NewOAuthSSEClient(conf.URL, prepareOAuthConfig(input, tokenStore), opts...)
 		if err != nil {
 			return fmt.Errorf("failed to create OAuth SSE client for token exchange: %w", err)
 		}

--- a/internal/service/mcp/upstream_oauth_test.go
+++ b/internal/service/mcp/upstream_oauth_test.go
@@ -243,6 +243,31 @@ func TestUpstreamOAuthDCRUnsupportedUserError(t *testing.T) {
 	}
 }
 
+func TestPrepareOAuthConfig_UsesProxyAwareHTTPClient(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+
+	cfg := prepareOAuthConfig(
+		&types.RegisterServerInput{
+			OAuthRedirectURI: "http://127.0.0.1:7777/oauth/callback",
+		},
+		mcpgoclient.NewMemoryTokenStore(),
+	)
+
+	require.NotNil(t, cfg.HTTPClient)
+	tr, ok := cfg.HTTPClient.Transport.(*http.Transport)
+	require.True(t, ok)
+	require.NotNil(t, tr.Proxy)
+
+	req, err := http.NewRequest(http.MethodGet, "https://upstream.example.com/.well-known/oauth-authorization-server", nil)
+	require.NoError(t, err)
+
+	proxyURL, err := tr.Proxy(req)
+	require.NoError(t, err)
+	require.NotNil(t, proxyURL)
+	require.Equal(t, "proxy.example.com:8080", proxyURL.Host)
+}
+
 func TestRegisterOAuthClientWithoutEmptyScope_OmitsScopeWhenUnset(t *testing.T) {
 	t.Parallel()
 
@@ -281,6 +306,66 @@ func TestRegisterOAuthClientWithoutEmptyScope_OmitsScopeWhenUnset(t *testing.T) 
 	if _, exists := upstream.lastRegisterBody["scope"]; exists {
 		t.Fatalf("expected scope to be omitted from DCR payload, got %#v", upstream.lastRegisterBody["scope"])
 	}
+}
+
+func TestRegisterOAuthClientWithoutEmptyScope_HonorsProxyEnv(t *testing.T) {
+	clearProxyEnv(t)
+
+	var proxySawRegistration bool
+	proxy := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost || r.URL.String() != "http://upstream.example/register" {
+			t.Fatalf("unexpected proxied request: %s %s", r.Method, r.URL.String())
+		}
+		proxySawRegistration = true
+
+		defer r.Body.Close()
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "mcpjungle-test", body["client_name"])
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"client_id": "proxied-client-id",
+		})
+	}))
+	defer proxy.Close()
+	t.Setenv("HTTP_PROXY", proxy.URL)
+
+	metadataServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"issuer":                 "http://upstream.example",
+			"authorization_endpoint": "http://upstream.example/authorize",
+			"token_endpoint":         "http://upstream.example/token",
+			"registration_endpoint":  "http://upstream.example/register",
+			"response_types_supported": []string{
+				"code",
+			},
+		})
+	}))
+	defer metadataServer.Close()
+
+	handler := mcpgotransport.NewOAuthHandler(mcpgotransport.OAuthConfig{
+		RedirectURI:           "http://127.0.0.1:7777/oauth/callback",
+		TokenStore:            mcpgoclient.NewMemoryTokenStore(),
+		AuthServerMetadataURL: metadataServer.URL,
+		HTTPClient: &http.Client{
+			Transport: &http.Transport{},
+		},
+	})
+
+	clientID, clientSecret, err := registerOAuthClientWithoutEmptyScope(
+		context.Background(),
+		handler,
+		&types.RegisterServerInput{
+			OAuthRedirectURI: "http://127.0.0.1:7777/oauth/callback",
+		},
+		"mcpjungle-test",
+	)
+	require.NoError(t, err)
+	require.Equal(t, "proxied-client-id", clientID)
+	require.Empty(t, clientSecret)
+	require.True(t, proxySawRegistration)
 }
 
 func TestBootstrapUpstreamOAuth_UsesConfiguredClientCredentialsWithoutDCR(t *testing.T) {

--- a/internal/service/mcp/util.go
+++ b/internal/service/mcp/util.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log"
 	"net"
+	"net/http"
 	"net/url"
 	"os"
 	"regexp"
@@ -20,6 +21,7 @@ import (
 	"github.com/mark3labs/mcp-go/mcp"
 	"github.com/mcpjungle/mcpjungle/internal/model"
 	"github.com/mcpjungle/mcpjungle/pkg/apierrors"
+	"golang.org/x/net/http/httpproxy"
 	"gorm.io/gorm"
 )
 
@@ -215,12 +217,39 @@ func convertResourceModelToMcpObject(r *model.Resource) (mcp.Resource, error) {
 	return mcpResource, nil
 }
 
+// proxyAwareHTTPClient returns an *http.Client whose transport honors the standard
+// HTTP_PROXY/HTTPS_PROXY/NO_PROXY environment variables (and their lowercase forms).
+// This allows mcpjungle to reach upstream MCP servers through a corporate/forward proxy.
+// When no proxy variables are set, the proxy function returns nil for every request, so
+// default (direct) behavior is unchanged.
+//
+// Unlike http.ProxyFromEnvironment (which caches the environment on first use), this reads
+// the proxy configuration from the environment each time the client is constructed.
+func proxyAwareHTTPClient() *http.Client {
+	proxyCfg := httpproxy.FromEnvironment()
+	proxyFunc := proxyCfg.ProxyFunc()
+
+	// Clone http.DefaultTransport so we keep its sensible defaults (dial/TLS timeouts,
+	// idle-connection cleanup, HTTP/2) and only override the proxy resolution.
+	tr := http.DefaultTransport.(*http.Transport).Clone()
+	tr.Proxy = func(req *http.Request) (*url.URL, error) {
+		return proxyFunc(req.URL)
+	}
+
+	return &http.Client{Transport: tr}
+}
+
 // prepareSHTTPClientOptions prepares the options (specifically, http headers) for creating a
 // streamable HTTP client based on the MCP server's configuration.
 // If a bearer token is provided in the config and a custom Authorization header is set, the custom header
 // takes precedence and the bearer token is ignored.
 func prepareSHTTPClientOptions(serverName string, conf *model.StreamableHTTPConfig) []transport.StreamableHTTPCOption {
 	var opts []transport.StreamableHTTPCOption
+
+	// Use a proxy-aware HTTP client so upstream connections honor
+	// HTTP_PROXY/HTTPS_PROXY/NO_PROXY. This also applies to the OAuth client path,
+	// which receives the same opts.
+	opts = append(opts, transport.WithHTTPBasicClient(proxyAwareHTTPClient()))
 
 	headers := map[string]string{}
 	for key, value := range conf.Headers {
@@ -303,6 +332,10 @@ func createHTTPMcpServerConn(
 						transport:  s.Transport,
 					},
 					PKCEEnabled: true,
+					// Use a proxy-aware HTTP client so the OAuth handler's own
+					// metadata/registration/token/refresh requests honor
+					// HTTP_PROXY/HTTPS_PROXY/NO_PROXY, matching the MCP transport.
+					HTTPClient: proxyAwareHTTPClient(),
 				}
 				c, err = client.NewOAuthStreamableHttpClient(conf.URL, oauthConfig, opts...)
 				if err != nil {
@@ -451,6 +484,12 @@ func createSSEMcpServerConn(
 		opts []transport.ClientOption
 		c    *client.Client
 	)
+
+	// Use a proxy-aware HTTP client so upstream SSE connections honor
+	// HTTP_PROXY/HTTPS_PROXY/NO_PROXY. This also applies to the OAuth client path,
+	// which receives the same opts.
+	opts = append(opts, transport.WithHTTPClient(proxyAwareHTTPClient()))
+
 	if conf.BearerToken != "" {
 		// If bearer token is provided, set the Authorization header
 		o := transport.WithHeaders(map[string]string{
@@ -478,6 +517,10 @@ func createSSEMcpServerConn(
 						transport:  s.Transport,
 					},
 					PKCEEnabled: true,
+					// Use a proxy-aware HTTP client so the OAuth handler's own
+					// metadata/registration/token/refresh requests honor
+					// HTTP_PROXY/HTTPS_PROXY/NO_PROXY, matching the MCP transport.
+					HTTPClient: proxyAwareHTTPClient(),
 				}
 				c, err = client.NewOAuthSSEClient(conf.URL, oauthConfig, opts...)
 				if err != nil {

--- a/internal/service/mcp/util_test.go
+++ b/internal/service/mcp/util_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"net/http"
 	"os"
 	"reflect"
 	"strings"
@@ -272,8 +273,10 @@ func TestPrepareSHTTPClientOptions_NoHeadersNoBearer(t *testing.T) {
 		Headers:     nil,
 	}
 	opts := prepareSHTTPClientOptions("srv", conf)
-	if len(opts) != 0 {
-		t.Fatalf("expected no options when no headers and no bearer token, got %d", len(opts))
+	// The proxy-aware HTTP client option is always present, even when no headers
+	// and no bearer token are configured.
+	if len(opts) != 1 {
+		t.Fatalf("expected 1 option (proxy client) when no headers and no bearer token, got %d", len(opts))
 	}
 }
 
@@ -286,8 +289,9 @@ func TestPrepareSHTTPClientOptions_HeaderOnly(t *testing.T) {
 		},
 	}
 	opts := prepareSHTTPClientOptions("srv", conf)
-	if len(opts) != 1 {
-		t.Fatalf("expected 1 option when headers present, got %d", len(opts))
+	// proxy client option + headers option
+	if len(opts) != 2 {
+		t.Fatalf("expected 2 options (proxy client + headers) when headers present, got %d", len(opts))
 	}
 }
 
@@ -298,8 +302,9 @@ func TestPrepareSHTTPClientOptions_BearerOnly(t *testing.T) {
 		Headers:     nil,
 	}
 	opts := prepareSHTTPClientOptions("srv", conf)
-	if len(opts) != 1 {
-		t.Fatalf("expected 1 option when bearer token present, got %d", len(opts))
+	// proxy client option + bearer-token-as-header option
+	if len(opts) != 2 {
+		t.Fatalf("expected 2 options (proxy client + bearer header) when bearer token present, got %d", len(opts))
 	}
 }
 
@@ -318,13 +323,108 @@ func TestPrepareSHTTPClientOptions_BearerWithCustomAuthorization(t *testing.T) {
 	defer log.SetOutput(old)
 
 	opts := prepareSHTTPClientOptions("my-server", conf)
-	if len(opts) != 1 {
-		t.Fatalf("expected 1 option when custom Authorization header present, got %d", len(opts))
+	// proxy client option + custom Authorization header option
+	if len(opts) != 2 {
+		t.Fatalf("expected 2 options (proxy client + custom Authorization header) when custom Authorization header present, got %d", len(opts))
 	}
 
 	logOutput := buf.String()
 	if !strings.Contains(logOutput, "custom Authorization header will be used for MCP server my-server; bearer_token ignored") {
 		t.Fatalf("expected log to mention bearer_token ignored when custom Authorization header present, got: %q", logOutput)
+	}
+}
+
+// clearProxyEnv unsets every proxy-related variable (both upper and lower case forms)
+// that httpproxy.FromEnvironment consults, so tests are not influenced by the ambient
+// CI/developer environment.
+func clearProxyEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{
+		"HTTP_PROXY", "http_proxy",
+		"HTTPS_PROXY", "https_proxy",
+		"NO_PROXY", "no_proxy",
+	} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestProxyAwareHTTPClient_HonorsHTTPSProxy(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+
+	c := proxyAwareHTTPClient()
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", c.Transport)
+	}
+	if tr.Proxy == nil {
+		t.Fatal("expected a non-nil Proxy function on the transport")
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://upstream.example.com/mcp", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	proxyURL, err := tr.Proxy(req)
+	if err != nil {
+		t.Fatalf("proxy func returned error: %v", err)
+	}
+	if proxyURL == nil {
+		t.Fatal("expected request to be proxied, got nil proxy URL")
+	}
+	if proxyURL.Host != "proxy.example.com:8080" {
+		t.Fatalf("expected proxy host proxy.example.com:8080, got %s", proxyURL.Host)
+	}
+}
+
+func TestProxyAwareHTTPClient_NoProxyEnvDefault(t *testing.T) {
+	clearProxyEnv(t)
+
+	c := proxyAwareHTTPClient()
+	tr, ok := c.Transport.(*http.Transport)
+	if !ok {
+		t.Fatalf("expected *http.Transport, got %T", c.Transport)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, "https://upstream.example.com/mcp", nil)
+	if err != nil {
+		t.Fatalf("failed to build request: %v", err)
+	}
+	proxyURL, err := tr.Proxy(req)
+	if err != nil {
+		t.Fatalf("proxy func returned error: %v", err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("expected no proxy when no env vars set, got %s", proxyURL)
+	}
+}
+
+func TestProxyAwareHTTPClient_NoProxyHonored(t *testing.T) {
+	clearProxyEnv(t)
+	t.Setenv("HTTPS_PROXY", "http://proxy.example.com:8080")
+	t.Setenv("NO_PROXY", "internal.example.com")
+
+	c := proxyAwareHTTPClient()
+	tr := c.Transport.(*http.Transport)
+
+	// A URL matching NO_PROXY must bypass the proxy.
+	bypassReq, _ := http.NewRequest(http.MethodGet, "https://internal.example.com/mcp", nil)
+	proxyURL, err := tr.Proxy(bypassReq)
+	if err != nil {
+		t.Fatalf("proxy func returned error: %v", err)
+	}
+	if proxyURL != nil {
+		t.Fatalf("expected NO_PROXY host to bypass proxy, got %s", proxyURL)
+	}
+
+	// A non-matching URL must still be proxied.
+	proxiedReq, _ := http.NewRequest(http.MethodGet, "https://upstream.example.com/mcp", nil)
+	proxyURL, err = tr.Proxy(proxiedReq)
+	if err != nil {
+		t.Fatalf("proxy func returned error: %v", err)
+	}
+	if proxyURL == nil || proxyURL.Host != "proxy.example.com:8080" {
+		t.Fatalf("expected non-matching host to be proxied via proxy.example.com:8080, got %v", proxyURL)
 	}
 }
 


### PR DESCRIPTION
## Summary

Honor the standard `HTTP_PROXY` / `HTTPS_PROXY` / `NO_PROXY` environment variables (and their lowercase forms) when the mcpjungle server opens outbound connections to upstream StreamableHTTP and SSE MCP servers.

Previously, upstream HTTP/SSE clients were built on mcp-go's default transport, which does not consult proxy environment variables. On isolated hosts that can only reach the internet through a corporate/forward proxy, registering or invoking remote upstream servers therefore failed.

Changes (`internal/service/mcp/util.go`):
- Add `proxyAwareHTTPClient()`, which builds an `*http.Client` from a clone of `http.DefaultTransport` (preserving its dial/TLS timeouts, idle-connection cleanup, and HTTP/2 support) and overrides only the proxy resolver. Proxy resolution is read from the environment via `golang.org/x/net/http/httpproxy`.
- Inject this client at both upstream injection points: `transport.WithHTTPBasicClient(...)` in `prepareSHTTPClientOptions` (StreamableHTTP) and `transport.WithHTTPClient(...)` in `createSSEMcpServerConn` (SSE). Because both call sites pass the same option slice to the OAuth client constructors (`NewOAuthStreamableHttpClient` / `NewOAuthSSEClient`), the OAuth paths pick up the proxy as well.

When no proxy variables are set, the proxy function returns `nil` for every request, so default direct-connection behavior is unchanged.

## Why this matters

Resolves the request in #279, where a user running mcpjungle on an isolated host needs the server's outbound connections to upstream MCP servers to traverse a corporate proxy. The maintainer scoped this on 2026-06-16 to the mcpjungle server's outbound upstream connections (not the CLI-to-registry connection), which is exactly what this change addresses.

## Testing

- `go test ./internal/service/mcp/...` passes locally.
- Added unit tests in `internal/service/mcp/util_test.go`:
  - `HTTPS_PROXY` set: the transport's proxy func resolves an upstream URL to the configured proxy.
  - No proxy env set: the proxy func returns `nil` (default behavior preserved).
  - `NO_PROXY` honored: a matching host bypasses the proxy while a non-matching host is still proxied.
  - Updated `prepareSHTTPClientOptions` option-count assertions to account for the always-present proxy client option.

## Pre-Agreement Checklist (required)

- [x] I have read and followed the contribution guidelines.
- [x] This PR addresses an existing issue (#279) with maintainer-confirmed scope.
- [x] An existing issue/discussion exists and was aligned with maintainers.
- [x] I confirmed the issue priority with maintainers.
- [x] I kept this PR focused and small.
- [x] Any AI-generated code in this PR was reviewed by a human author.

## Validation Checklist

- [x] `go test ./internal/service/mcp/...` passes locally.
- [x] I added tests for the new behavior.
- [ ] User-facing documentation update (none required; behavior is automatic and opt-in via standard env vars).

## Linked Context

- Issue(s): #279

Fixes #279
