### PR TITLE
Record tool-level errors (CallToolResult.IsError) as error outcome

### DIFF
--- a/internal/service/mcp/proxy.go
+++ b/internal/service/mcp/proxy.go
@@ -77,6 +77,10 @@ func (m *MCPService) MCPProxyToolCallHandler(ctx context.Context, request mcp.Ca
 	if err != nil {
 		outcome = telemetry.ToolCallOutcomeError
 		session.invalidateOnError(err) // Invalidate unhealthy stateful sessions
+	} else if res != nil && res.IsError {
+		// The call completed but the tool reported a tool-level error
+		// (CallToolResult.IsError); count it as an error, not a success.
+		outcome = telemetry.ToolCallOutcomeError
 	}
 
 	// forward the request to the upstream MCP server and relay the response back

--- a/internal/service/mcp/proxy_iserror_test.go
+++ b/internal/service/mcp/proxy_iserror_test.go
@@ -1,0 +1,96 @@
+package mcp
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/mark3labs/mcp-go/mcp"
+	mcpserver "github.com/mark3labs/mcp-go/server"
+	"github.com/mcpjungle/mcpjungle/internal/model"
+	"github.com/mcpjungle/mcpjungle/internal/telemetry"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// outcomeCapture is a telemetry.CustomMetrics that records the last tool-call
+// outcome, so a test can assert what was recorded.
+type outcomeCapture struct {
+	tool telemetry.ToolCallOutcome
+}
+
+func (o *outcomeCapture) RecordToolCall(_ context.Context, _, _ string, outcome telemetry.ToolCallOutcome, _ time.Duration) {
+	o.tool = outcome
+}
+
+func (o *outcomeCapture) RecordPromptCall(_ context.Context, _, _ string, _ telemetry.PromptCallOutcome, _ time.Duration) {
+}
+
+// A tool that completes without a transport error but returns a tool-level error
+// (CallToolResult.IsError) must be recorded as an "error" outcome, not "success".
+func TestMCPProxyToolCallHandler_RecordsToolLevelErrorAsErrorOutcome(t *testing.T) {
+	db := setupTestDBForProxyAdditional(t)
+
+	upstream := mcpserver.NewMCPServer("Upstream", "0.1.0", mcpserver.WithToolCapabilities(true))
+	upstream.AddTool(
+		mcp.NewTool("boom"),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultError("kaboom"), nil
+		},
+	)
+
+	httpServer := newUpstreamStreamableHTTPServer(t, upstream)
+	defer httpServer.Close()
+
+	srv := createStreamableHTTPTestServer(t, "tool-server", httpServer.URL)
+	require.NoError(t, db.Create(srv).Error)
+
+	metrics := &outcomeCapture{}
+	service := &MCPService{
+		db:                         db,
+		metrics:                    metrics,
+		mcpServerInitReqTimeoutSec: 5,
+	}
+
+	req := mcp.CallToolRequest{}
+	req.Params.Name = "tool-server__boom"
+
+	res, err := service.MCPProxyToolCallHandler(context.WithValue(context.Background(), "mode", model.ModeDev), req)
+	require.NoError(t, err)
+	require.NotNil(t, res)
+	assert.True(t, res.IsError)
+	assert.Equal(t, telemetry.ToolCallOutcomeError, metrics.tool)
+}
+
+// The REST InvokeTool path has the same contract: a completed call whose result
+// is a tool-level error (CallToolResult.IsError) must record an "error" outcome.
+func TestInvokeTool_RecordsToolLevelErrorAsErrorOutcome(t *testing.T) {
+	db := setupTestDBForProxyAdditional(t)
+
+	upstream := mcpserver.NewMCPServer("Upstream", "0.1.0", mcpserver.WithToolCapabilities(true))
+	upstream.AddTool(
+		mcp.NewTool("boom"),
+		func(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+			return mcp.NewToolResultError("kaboom"), nil
+		},
+	)
+
+	httpServer := newUpstreamStreamableHTTPServer(t, upstream)
+	defer httpServer.Close()
+
+	srv := createStreamableHTTPTestServer(t, "tool-server", httpServer.URL)
+	require.NoError(t, db.Create(srv).Error)
+
+	metrics := &outcomeCapture{}
+	service := &MCPService{
+		db:                         db,
+		metrics:                    metrics,
+		mcpServerInitReqTimeoutSec: 5,
+	}
+
+	result, err := service.InvokeTool(context.Background(), "tool-server__boom", nil)
+	require.NoError(t, err)
+	require.NotNil(t, result)
+	assert.True(t, result.IsError)
+	assert.Equal(t, telemetry.ToolCallOutcomeError, metrics.tool)
+}

--- a/internal/service/mcp/tool.go
+++ b/internal/service/mcp/tool.go
@@ -164,7 +164,11 @@ func (m *MCPService) InvokeTool(ctx context.Context, name string, args map[strin
 		return nil, fmt.Errorf("failed to convert MCP response to api response: %w", err)
 	}
 
-	outcome = telemetry.ToolCallOutcomeSuccess
+	// A completed call can still be a tool-level error (CallToolResult.IsError);
+	// only record success when the tool did not report an error.
+	if !callToolResp.IsError {
+		outcome = telemetry.ToolCallOutcomeSuccess
+	}
 
 	return result, nil
 }


### PR DESCRIPTION
## Summary
A tool call that *completes* (no transport error) but returns a **tool-level error**
(`CallToolResult.IsError == true`) is currently recorded as a **successful** call in the metrics, so
`mcpjungle_tool_calls_total{outcome="..."}` undercounts errors — a tool that fails every call still
shows a 100% success rate. Both recording paths only flip `outcome` to `error` on the Go `err`:
`MCPProxyToolCallHandler` (`internal/service/mcp/proxy.go`) ignores `res.IsError`, and `InvokeTool`
(`internal/service/mcp/tool.go`) sets `success` unconditionally once the response converts.

This treats a completed-but-`IsError` result as an `error` outcome in both paths — proxy adds
`else if res != nil && res.IsError { outcome = error }`; invoke only sets `success` when
`!callToolResp.IsError`. **No API/behavior change** — the same result is still returned to the caller;
only the recorded metric label changes. No migration, no config.

Closes #282.

## Pre-Agreement Checklist (required)
- [x] I have read and followed the contribution guidelines.
- [x] This PR addresses an existing issue or a concluded discussion.
- [x] If there was no existing issue/discussion, I opened one first to align with maintainers before submitting this PR.
- [ ] I confirmed the issue/discussion priority with maintainers and understand low-priority items may receive limited attention.
- [x] I kept this PR focused and reasonably small.
- [x] Any AI-generated code in this PR was reviewed by a human author.

## Validation Checklist
- [x] `go test ./...` passes locally.
- [x] `scripts/test-mcpjungle.sh` passes locally.
- [x] I added or updated tests for new behavior (two regression tests, one per recording path:
      `TestMCPProxyToolCallHandler_RecordsToolLevelErrorAsErrorOutcome`,
      `TestInvokeTool_RecordsToolLevelErrorAsErrorOutcome` — both fail on `main`, pass with this change).
- [x] I updated documentation for user-facing changes where applicable (none — metric-label only).

## Linked Context
- Issue(s): #282
- Discussion(s): —
