### PR TITLE
docs: add Security Companion section (mcp-slim-guard)

### DIFF
--- a/README.md
+++ b/README.md
@@ -998,6 +998,36 @@ This is a work in progress.
 
 We're collecting more feedback on how people use OAuth with MCP servers, so feel free to start a Discussion or open an issue to share your use case.
 
+# 🔒 Security Companion: mcp-slim-guard
+
+MCPJungle gives you one endpoint for all your MCP tools with tool groups and access control. For defense-in-depth, layer **[mcp-slim-guard](https://github.com/lennney/mcp-slim-guard)** — an MIT-licensed MCP security proxy — in front:
+
+```
+AI Client → mcp-slim-guard → MCPJungle → Your MCP Servers
+```
+
+**What mcp-slim-guard adds on top of MCPJungle:**
+
+| Feature | What it does |
+|---------|-------------|
+| **SSRF Protection** | Blocks requests to internal IPs (10.\*, 192.168.\*, 169.254.\*) |
+| **Injection Detection** | 17 heuristic patterns for shell/SQL/NoSQL/prompt injection |
+| **Schema Compression** | Up to 83% token savings on tool schemas — less context waste |
+| **Rate Limiting** | Per-tool token bucket, independent of MCPJungle's access control |
+| **Audit Logging** | Structured JSON log with rotation — immutable record of every tool call |
+
+**One-command setup:**
+
+```bash
+npm install -g mcp-slim-guard
+mcp-slim-guard init   # auto-discovers MCP config
+mcp-slim-guard start  # starts the proxy
+```
+
+Then configure your AI client to connect to `mcp-slim-guard` instead of MCPJungle directly, and set MCPJungle as the upstream in `mcp-slim-guard.yml`.
+
+MCPJungle **manages** which tools clients can see. mcp-slim-guard **protects** every call that passes through.
+
 # Contributing 💻
 
 We welcome contributions from the community! 


### PR DESCRIPTION
## What

Add a "🔒 Security Companion: mcp-slim-guard" section to the README, showing how to layer mcp-slim-guard in front of MCPJungle for defense-in-depth.

## Why

MCPJungle provides tool groups and client-level access control — it manages **which** tools clients can see. It does not yet provide:

- SSRF protection (blocking internal IP access from tool parameters)
- Injection detection (shell/SQL/prompt injection in tool arguments)
- Schema compression (reducing context window waste from tool schemas)
- Rate limiting at the tool-call level
- Structured audit logging of every tool invocation

[mcp-slim-guard](https://github.com/lennney/mcp-slim-guard) is a complementary MIT-licensed proxy that adds these protections **without overlapping** with MCPJungle's existing features.

## Architecture

```
AI Client → mcp-slim-guard → MCPJungle → Your MCP Servers
```

MCPJungle **manages** which tools clients can see. mcp-slim-guard **protects** every call that passes through. They complement each other.

## Changes

- 30 lines added to README.md
- New section placed between Current Limitations and Contributing