### PR TITLE
feat(server): add --host / MCPJUNGLE_HOST to choose the bind interface

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -243,18 +243,19 @@ func isTelemetryEnabled(desiredServerMode model.ServerMode) (bool, error) {
 	return telemetryEnabled, nil
 }
 
-// getBindPort returns the TCP port to bind the mcpjungle server to
-// precedence: command line flag > environment variable > default
 // getBindHost returns the interface to bind to.
 // precedence: command line flag > environment variable > all interfaces
+// An explicit empty --host is meaningful: it forces the historical all-interface
+// bind even when MCPJUNGLE_HOST is set.
 func getBindHost() string {
-	host := startServerCmdBindHost
-	if host == "" {
-		host = os.Getenv(BindHostEnvVar)
+	if startServerCmd.Flags().Changed("host") {
+		return startServerCmdBindHost
 	}
-	return host
+	return os.Getenv(BindHostEnvVar)
 }
 
+// getBindPort returns the TCP port to bind the mcpjungle server to
+// precedence: command line flag > environment variable > default
 func getBindPort() string {
 	port := startServerCmdBindPort
 	if port == "" {

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -36,6 +36,13 @@ const (
 	BindPortEnvVar  = "PORT"
 	BindPortDefault = "8080"
 
+	// BindHostEnvVar configures the interface the HTTP server binds to.
+	// Empty (the default) keeps the historical behaviour of listening on every
+	// interface; "127.0.0.1" makes a local gateway reachable only from the host,
+	// which matters because a development-mode server has no authentication and
+	// its tools can act on the upstreams it proxies.
+	BindHostEnvVar = "MCPJUNGLE_HOST"
+
 	DBUrlEnvVar            = "DATABASE_URL"
 	SQLiteDBPathEnvVar     = "SQLITE_DB_PATH"
 	ServerModeEnvVar       = "SERVER_MODE"
@@ -66,6 +73,7 @@ const (
 )
 
 var (
+	startServerCmdBindHost          string
 	startServerCmdBindPort          string
 	startServerCmdSQLiteDBPath      string
 	startServerCmdEnterpriseEnabled bool
@@ -103,6 +111,16 @@ func init() {
 		"port",
 		"",
 		fmt.Sprintf("port to bind the HTTP server to (overrides env var %s)", BindPortEnvVar),
+	)
+	startServerCmd.Flags().StringVar(
+		&startServerCmdBindHost,
+		"host",
+		"",
+		fmt.Sprintf(
+			"host/interface to bind the HTTP server to, eg- 127.0.0.1 for local-only access "+
+				"(overrides env var %s; empty means all interfaces)",
+			BindHostEnvVar,
+		),
 	)
 	startServerCmd.Flags().StringVar(
 		&startServerCmdSQLiteDBPath,
@@ -227,6 +245,16 @@ func isTelemetryEnabled(desiredServerMode model.ServerMode) (bool, error) {
 
 // getBindPort returns the TCP port to bind the mcpjungle server to
 // precedence: command line flag > environment variable > default
+// getBindHost returns the interface to bind to.
+// precedence: command line flag > environment variable > all interfaces
+func getBindHost() string {
+	host := startServerCmdBindHost
+	if host == "" {
+		host = os.Getenv(BindHostEnvVar)
+	}
+	return host
+}
+
 func getBindPort() string {
 	port := startServerCmdBindPort
 	if port == "" {
@@ -421,6 +449,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 	}
 
 	bindPort := getBindPort()
+	bindAddr := net.JoinHostPort(getBindHost(), bindPort)
 
 	mcpProxyServer, sseMcpProxyServer := newProxyServers()
 
@@ -526,14 +555,14 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 
 	// Display startup banner when the server is started
 	cmd.Print(asciiArt)
-	cmd.Printf("MCPJungle HTTP server listening on :%s\n\n", bindPort)
+	cmd.Printf("MCPJungle HTTP server listening on %s\n\n", bindAddr)
 
 	// Create a cancellable base context for all requests - when cancelled, all active connections terminate
 	requestBaseCtx, cancelRequests := context.WithCancel(context.Background())
 
 	// Create HTTP server for graceful shutdown support
 	httpServer := &http.Server{
-		Addr:    ":" + bindPort,
+		Addr:    bindAddr,
 		Handler: s.Router(),
 		BaseContext: func(l net.Listener) context.Context {
 			return requestBaseCtx

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -33,6 +33,8 @@ import (
 )
 
 const (
+	// TODO: Add MCPJUNGLE_BIND_PORT while keeping PORT for backward compatibility,
+	// matching the MCPJUNGLE_BIND_HOST naming pattern.
 	BindPortEnvVar  = "PORT"
 	BindPortDefault = "8080"
 
@@ -41,7 +43,7 @@ const (
 	// interface; "127.0.0.1" makes a local gateway reachable only from the host,
 	// which matters because a development-mode server has no authentication and
 	// its tools can act on the upstreams it proxies.
-	BindHostEnvVar = "MCPJUNGLE_HOST"
+	BindHostEnvVar = "MCPJUNGLE_BIND_HOST"
 
 	DBUrlEnvVar            = "DATABASE_URL"
 	SQLiteDBPathEnvVar     = "SQLITE_DB_PATH"
@@ -246,9 +248,9 @@ func isTelemetryEnabled(desiredServerMode model.ServerMode) (bool, error) {
 // getBindHost returns the interface to bind to.
 // precedence: command line flag > environment variable > all interfaces
 // An explicit empty --host is meaningful: it forces the historical all-interface
-// bind even when MCPJUNGLE_HOST is set.
-func getBindHost() string {
-	if startServerCmd.Flags().Changed("host") {
+// bind even when MCPJUNGLE_BIND_HOST is set.
+func getBindHost(cmd *cobra.Command) string {
+	if cmd.Flags().Changed("host") {
 		return startServerCmdBindHost
 	}
 	return os.Getenv(BindHostEnvVar)
@@ -450,7 +452,7 @@ func runStartServer(cmd *cobra.Command, args []string) error {
 	}
 
 	bindPort := getBindPort()
-	bindAddr := net.JoinHostPort(getBindHost(), bindPort)
+	bindAddr := net.JoinHostPort(getBindHost(cmd), bindPort)
 
 	mcpProxyServer, sseMcpProxyServer := newProxyServers()
 

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -111,7 +111,7 @@ func TestGetBindHost(t *testing.T) {
 			withEnv(map[string]string{
 				BindHostEnvVar: "",
 			}, func() {
-				if got := getBindHost(); got != "" {
+				if got := getBindHost(startServerCmd); got != "" {
 					t.Fatalf("expected empty bind host, got %q", got)
 				}
 			})
@@ -123,7 +123,7 @@ func TestGetBindHost(t *testing.T) {
 			withEnv(map[string]string{
 				BindHostEnvVar: "127.0.0.1",
 			}, func() {
-				if got := getBindHost(); got != "127.0.0.1" {
+				if got := getBindHost(startServerCmd); got != "127.0.0.1" {
 					t.Fatalf("expected env bind host, got %q", got)
 				}
 			})
@@ -135,7 +135,7 @@ func TestGetBindHost(t *testing.T) {
 			withEnv(map[string]string{
 				BindHostEnvVar: "127.0.0.1",
 			}, func() {
-				if got := getBindHost(); got != "0.0.0.0" {
+				if got := getBindHost(startServerCmd); got != "0.0.0.0" {
 					t.Fatalf("expected flag bind host, got %q", got)
 				}
 			})
@@ -147,7 +147,7 @@ func TestGetBindHost(t *testing.T) {
 			withEnv(map[string]string{
 				BindHostEnvVar: "127.0.0.1",
 			}, func() {
-				if got := getBindHost(); got != "" {
+				if got := getBindHost(startServerCmd); got != "" {
 					t.Fatalf("expected empty bind host from explicit flag, got %q", got)
 				}
 			})

--- a/cmd/start_test.go
+++ b/cmd/start_test.go
@@ -51,6 +51,14 @@ func TestStartCommandFlags(t *testing.T) {
 		}
 	})
 
+	t.Run("start command has host flag", func(t *testing.T) {
+		if hostFlag := startServerCmd.Flags().Lookup("host"); hostFlag == nil {
+			t.Fatal("Start command missing 'host' flag")
+		} else if hostFlag.Usage == "" {
+			t.Error("host flag should have usage description")
+		}
+	})
+
 	t.Run("start command has sqlite db path flag", func(t *testing.T) {
 		if sqlitePathFlag := startServerCmd.Flags().Lookup("sqlite-db-path"); sqlitePathFlag == nil {
 			t.Fatal("Start command missing 'sqlite-db-path' flag")
@@ -73,6 +81,77 @@ func TestStartCommandFlags(t *testing.T) {
 		} else if prodFlag.Usage == "" {
 			t.Error("prod flag should have usage description")
 		}
+	})
+}
+
+func withBindHostFlag(t *testing.T, value string, changed bool, fn func()) {
+	t.Helper()
+
+	hostFlag := startServerCmd.Flags().Lookup("host")
+	if hostFlag == nil {
+		t.Fatal("Start command missing 'host' flag")
+	}
+
+	originalValue := startServerCmdBindHost
+	originalChanged := hostFlag.Changed
+
+	startServerCmdBindHost = value
+	hostFlag.Changed = changed
+	defer func() {
+		startServerCmdBindHost = originalValue
+		hostFlag.Changed = originalChanged
+	}()
+
+	fn()
+}
+
+func TestGetBindHost(t *testing.T) {
+	t.Run("returns empty string when unset", func(t *testing.T) {
+		withBindHostFlag(t, "", false, func() {
+			withEnv(map[string]string{
+				BindHostEnvVar: "",
+			}, func() {
+				if got := getBindHost(); got != "" {
+					t.Fatalf("expected empty bind host, got %q", got)
+				}
+			})
+		})
+	})
+
+	t.Run("uses env var when flag is unset", func(t *testing.T) {
+		withBindHostFlag(t, "", false, func() {
+			withEnv(map[string]string{
+				BindHostEnvVar: "127.0.0.1",
+			}, func() {
+				if got := getBindHost(); got != "127.0.0.1" {
+					t.Fatalf("expected env bind host, got %q", got)
+				}
+			})
+		})
+	})
+
+	t.Run("flag takes precedence over env var", func(t *testing.T) {
+		withBindHostFlag(t, "0.0.0.0", true, func() {
+			withEnv(map[string]string{
+				BindHostEnvVar: "127.0.0.1",
+			}, func() {
+				if got := getBindHost(); got != "0.0.0.0" {
+					t.Fatalf("expected flag bind host, got %q", got)
+				}
+			})
+		})
+	})
+
+	t.Run("explicit empty flag overrides env var", func(t *testing.T) {
+		withBindHostFlag(t, "", true, func() {
+			withEnv(map[string]string{
+				BindHostEnvVar: "127.0.0.1",
+			}, func() {
+				if got := getBindHost(); got != "" {
+					t.Fatalf("expected empty bind host from explicit flag, got %q", got)
+				}
+			})
+		})
 	})
 }
 

--- a/docs/reference/cli-server.mdx
+++ b/docs/reference/cli-server.mdx
@@ -13,12 +13,16 @@ Starts the Mcpjungle HTTP server and MCP gateway.
 mcpjungle start [flags]
 ```
 
-The server listens on port `8080` by default and exposes the MCP proxy at `/mcp`. On first run in development mode, it automatically initializes itself — no additional setup is needed.
+The server listens on all interfaces on port `8080` by default and exposes the MCP proxy at `/mcp`. On first run in development mode, it automatically initializes itself — no additional setup is needed.
 
 ### Flags
 
 <ParamField body="--port" type="string">
   TCP port to bind the HTTP server to. Overrides the `PORT` environment variable. Defaults to `8080`.
+</ParamField>
+
+<ParamField body="--host" type="string">
+  Host or network interface to bind the HTTP server to. Overrides the `MCPJUNGLE_BIND_HOST` environment variable. Defaults to all interfaces. Use `127.0.0.1` for local-only access.
 </ParamField>
 
 <ParamField body="--sqlite-db-path" type="string">
@@ -47,6 +51,12 @@ Start on a custom port:
 
 ```bash
 mcpjungle start --port 9000
+```
+
+Start with local-only network access:
+
+```bash
+mcpjungle start --host 127.0.0.1
 ```
 
 Start with a custom SQLite file:

--- a/docs/reference/environment-variables.mdx
+++ b/docs/reference/environment-variables.mdx
@@ -94,6 +94,15 @@ When the server starts it resolves the database connection in this order:
 
 ## Server
 
+<ParamField path="MCPJUNGLE_BIND_HOST" type="string">
+  Host or network interface the HTTP server binds to. The `--host` CLI flag takes precedence over this variable. If unset, MCPJungle listens on all interfaces.
+
+  ```bash
+  export MCPJUNGLE_BIND_HOST=127.0.0.1
+  mcpjungle start
+  ```
+</ParamField>
+
 <ParamField path="PORT" type="string" default="8080">
   TCP port the HTTP server listens on. The `--port` CLI flag takes precedence over this variable.
 
@@ -211,6 +220,7 @@ When the server starts it resolves the database connection in this order:
 | `POSTGRES_PASSWORD_FILE` | Database | — | File path for PostgreSQL password. |
 | `POSTGRES_DB` | Database | `postgres` | PostgreSQL database name. |
 | `POSTGRES_DB_FILE` | Database | — | File path for PostgreSQL database name. |
+| `MCPJUNGLE_BIND_HOST` | Server | all interfaces | HTTP listen host or network interface. |
 | `PORT` | Server | `8080` | HTTP listen port. |
 | `SERVER_MODE` | Server | `development` | Server mode: `development` or `enterprise`. |
 | `MCP_SERVER_INIT_REQ_TIMEOUT_SEC` | Server | `30` | Seconds to wait for MCP server initialization. |

--- a/scripts/test-mcpjungle.sh
+++ b/scripts/test-mcpjungle.sh
@@ -12,6 +12,8 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"   # repo root
 BIN_PATH="$ROOT_DIR/bin/mcpjungle"                            # compiled binary
 REGISTRY_PORT="${REGISTRY_PORT:-18080}"
 REGISTRY_URL="http://127.0.0.1:${REGISTRY_PORT}"              # local registry
+BIND_HOST_TEST_PORT="${BIND_HOST_TEST_PORT:-18084}"
+BIND_HOST_TEST_URL="http://127.0.0.1:${BIND_HOST_TEST_PORT}"
 OAUTH_MOCK_PORT="${OAUTH_MOCK_PORT:-18081}"
 OAUTH_MOCK_URL="http://127.0.0.1:${OAUTH_MOCK_PORT}"
 ENTERPRISE_PORT="${ENTERPRISE_PORT:-18082}"
@@ -122,6 +124,10 @@ cleanup_temp_files() {
     rm -f "$REGISTRY_LOG"
   fi
 
+  if [[ -n "${BIND_HOST_TEST_LOG:-}" ]]; then
+    rm -f "$BIND_HOST_TEST_LOG"
+  fi
+
   if [[ -n "${ENTERPRISE_LOG:-}" ]]; then
     rm -f "$ENTERPRISE_LOG"
   fi
@@ -160,6 +166,10 @@ cleanup_temp_files() {
 
   if [[ -n "${REGISTRY_RUNTIME_DIR:-}" ]]; then
     rm -rf "$REGISTRY_RUNTIME_DIR"
+  fi
+
+  if [[ -n "${BIND_HOST_TEST_RUNTIME_DIR:-}" ]]; then
+    rm -rf "$BIND_HOST_TEST_RUNTIME_DIR"
   fi
 
   if [[ -n "${ENTERPRISE_RUNTIME_DIR:-}" ]]; then
@@ -666,7 +676,29 @@ mkdir -p "$ROOT_DIR/bin"
 pushd "$ROOT_DIR" >/dev/null
 go build -o "$BIN_PATH" .
 
-# 2) Start local server + wait for health
+# 2) Verify host binding configuration
+log "Testing MCPJUNGLE_BIND_HOST bind address"
+BIND_HOST_TEST_RUNTIME_DIR=$(mktemp -d)
+BIND_HOST_TEST_SQLITE_DB_PATH="$BIND_HOST_TEST_RUNTIME_DIR/.mcpjungle.db"
+BIND_HOST_TEST_LOG=$(mktemp)
+(
+  cd "$BIND_HOST_TEST_RUNTIME_DIR"
+  MCPJUNGLE_BIND_HOST=127.0.0.1 exec "$BIN_PATH" start --port "$BIND_HOST_TEST_PORT" --sqlite-db-path "$BIND_HOST_TEST_SQLITE_DB_PATH"
+) >"$BIND_HOST_TEST_LOG" 2>&1 &
+BIN_SERVER_PID=$!
+
+wait_for_health "$BIND_HOST_TEST_URL/health"
+if ! grep -q "MCPJungle HTTP server listening on 127.0.0.1:${BIND_HOST_TEST_PORT}" "$BIND_HOST_TEST_LOG"; then
+  echo "ERROR: expected MCPJUNGLE_BIND_HOST startup banner to include 127.0.0.1:${BIND_HOST_TEST_PORT}" >&2
+  cat "$BIND_HOST_TEST_LOG" >&2
+  exit 1
+fi
+
+kill "$BIN_SERVER_PID" || true
+wait "$BIN_SERVER_PID" 2>/dev/null || true
+unset BIN_SERVER_PID
+
+# 3) Start local server + wait for health
 log "Starting server via local binary on port ${REGISTRY_PORT}"
 reset_runtime_state
 REGISTRY_RUNTIME_DIR=$(mktemp -d)
@@ -687,12 +719,12 @@ if [[ -f "$REGISTRY_RUNTIME_DIR/mcpjungle.db" ]]; then
   exit 1
 fi
 
-# 3) Basic CLI sanity checks
+# 4) Basic CLI sanity checks
 log "Verifying CLI help and version"
 "$BIN_PATH" --help >/dev/null
 "$BIN_PATH" --registry "$REGISTRY_URL" version
 
-# 4) Register a test MCP server (idempotent)
+# 5) Register a test MCP server (idempotent)
 log "Ensuring 'context7' server is registered"
 if ! "$BIN_PATH" --registry "$REGISTRY_URL" list servers 2>/dev/null | grep -q "context7"; then
   "$BIN_PATH" --registry "$REGISTRY_URL" register \
@@ -703,7 +735,7 @@ else
   log "'context7' already registered"
 fi
 
-# 5) Exercise tools via registry
+# 6) Exercise tools via registry
 log "Listing tools"
 "$BIN_PATH" --registry "$REGISTRY_URL" list tools
 
@@ -711,7 +743,7 @@ log "Invoking context7__resolve-library-id"
 "$BIN_PATH" --registry "$REGISTRY_URL" invoke context7__resolve-library-id \
   --input '{"libraryName":"lodash"}' >/dev/null
 
-# 6) Test upstream OAuth registration and later authenticated tool calls
+# 7) Test upstream OAuth registration and later authenticated tool calls
 log "Testing upstream OAuth registration flow with a local mock MCP server"
 start_mock_oauth_upstream
 wait_for_health "${OAUTH_MOCK_URL}/healthz"
@@ -783,7 +815,7 @@ if [[ "$OAUTH_STATEFUL_SECOND_INVOKE" != *"oauth echo: hello stateful oauth agai
   exit 1
 fi
 
-# 7) Test filesystem MCP server on the local host
+# 8) Test filesystem MCP server on the local host
 log "Testing filesystem MCP server on the local host"
 
 if ! "$BIN_PATH" --registry "$REGISTRY_URL" init-server; then
@@ -808,7 +840,7 @@ unset FS_CONFIG
 
 "$BIN_PATH" --registry "$REGISTRY_URL" invoke filesystem__list_allowed_directories --input '{}' >/dev/null
 
-# 8) Test stateful session mode
+# 9) Test stateful session mode
 log "Testing stateful session mode (session reuse for faster subsequent calls)"
 LOCAL_REGISTRY="$REGISTRY_URL"
 
@@ -848,7 +880,7 @@ else
   log "⚠️  Times similar (MCP server may have fast startup)"
 fi
 
-# 9) Test tool groups
+# 10) Test tool groups
 log "Testing tool groups"
 
 GROUP_CONFIG=$(mktemp)
@@ -895,7 +927,7 @@ if [[ "$GROUP_INVOKE_OUTPUT" != *"oauth echo: hello group"* ]]; then
   exit 1
 fi
 
-# 10) Test enterprise-only user and MCP client features
+# 11) Test enterprise-only user and MCP client features
 log "Testing enterprise users and MCP clients"
 
 ENTERPRISE_RUNTIME_DIR=$(mktemp -d)
@@ -990,7 +1022,7 @@ HOME="$ENTERPRISE_ADMIN_HOME" "$BIN_PATH" --registry "$ENTERPRISE_URL" create gr
 rm -f "$ENTERPRISE_GROUP_CONFIG"
 unset ENTERPRISE_GROUP_CONFIG
 
-# 11) Test enterprise export for currently supported entities
+# 12) Test enterprise export for currently supported entities
 log "Testing enterprise export"
 
 ENTERPRISE_EXPORT_DIR=$(mktemp -d)
@@ -1020,11 +1052,11 @@ if ! grep -q '"name": "enterprise-group"' "$ENTERPRISE_EXPORT_DIR/groups/enterpr
   exit 1
 fi
 
-# 12) Print Homebrew formula config snippet
+# 13) Print Homebrew formula config snippet
 log "Homebrew formula config (from .goreleaser.yaml)"
 sed -n '/^brews:/,/^dockers:/p' "$ROOT_DIR/.goreleaser.yaml" || true
 
-# 13) Run manual API error response verification against an isolated server
+# 14) Run manual API error response verification against an isolated server
 log "Running manual API error response verification"
 BIN_PATH="$BIN_PATH" "$ROOT_DIR/scripts/test-api-error-responses.sh"
 popd >/dev/null


### PR DESCRIPTION
### Problem

`mcpjungle start` builds its listen address as `":" + port` ([`cmd/start.go`](https://github.com/mcpjungle/MCPJungle/blob/main/cmd/start.go)), so the server always listens on every interface, and there is no way to ask for anything else — passing an address through the existing flag fails:

```
$ mcpjungle start --port 127.0.0.1:8091
MCPJungle HTTP server listening on :127.0.0.1:8091
failed to run the server: listen tcp: address :127.0.0.1:8091: too many colons in address
```

For a server running in development mode this is a security-relevant default: there is no authentication, so on a machine with a LAN address the gateway — and with it every tool of every upstream registered behind it — is reachable from the whole network. Right now the only remedy is a host firewall rule.

### Change

`--host`, mirroring `--port`: flag > `MCPJUNGLE_HOST` env var > default. The address is assembled with `net.JoinHostPort`.

The default is the empty string, which `net.JoinHostPort("", "8080")` renders as `":8080"` — byte for byte the current behaviour, so existing deployments are unaffected.

```
mcpjungle start --host 127.0.0.1
MCPJUNGLE_HOST=127.0.0.1 mcpjungle start
```

### Verification

Built from this branch and checked both paths:

```
$ mcpjungle start --host 127.0.0.1 --port 8093
MCPJungle HTTP server listening on 127.0.0.1:8093
LISTEN 0 4096 127.0.0.1:8093 0.0.0.0:*

$ mcpjungle start --port 8094
MCPJungle HTTP server listening on :8094
LISTEN 0 4096 *:8094 *:*
```

The startup banner now prints the actual address instead of a hardcoded `:%s`.