### PR TITLE
CLI: trim long tool descriptions

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -201,7 +201,7 @@ func runListTools(cmd *cobra.Command, args []string) error {
 			ed = "DISABLED"
 		}
 		cmd.Printf("%d. %s  [%s]\n", i+1, t.Name, ed)
-		cmd.Println(t.Description)
+		cmd.Println(summarizeToolDescription(t.Description))
 		cmd.Println()
 	}
 

--- a/cmd/list_run_test.go
+++ b/cmd/list_run_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/mcpjungle/mcpjungle/client"
@@ -63,5 +64,47 @@ func TestRunListTools_GroupUsesEffectiveToolsAPI(t *testing.T) {
 	}
 	if bytes.Contains([]byte(output), []byte("ghost")) {
 		t.Fatalf("did not expect output to contain non-existing tool, got: %s", output)
+	}
+}
+
+func TestRunListTools_TrimsToolDescriptions(t *testing.T) {
+	description := strings.Repeat("a", 40) + "\n\t" + strings.Repeat("b", 50)
+	wantSummary := strings.Repeat("a", 40) + " " + strings.Repeat("b", 36) + "..."
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api/v0/tools" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_ = json.NewEncoder(w).Encode([]*types.Tool{
+			{Name: "long-tool", Description: description, Enabled: true},
+		})
+	}))
+	defer server.Close()
+
+	origClient := apiClient
+	origServer := listToolsCmdServerName
+	origGroup := listToolsCmdGroupName
+	defer func() {
+		apiClient = origClient
+		listToolsCmdServerName = origServer
+		listToolsCmdGroupName = origGroup
+	}()
+
+	apiClient = client.NewClient(server.URL, "", http.DefaultClient)
+	listToolsCmdServerName = ""
+	listToolsCmdGroupName = ""
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := runListTools(cmd, nil); err != nil {
+		t.Fatalf("runListTools returned error: %v", err)
+	}
+
+	want := "\n" + wantSummary + "\n\n"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("expected trimmed tool description %q, got: %s", want, out.String())
 	}
 }

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -240,7 +240,7 @@ func printRegisteredServerSummary(cmd *cobra.Command, s *types.McpServer) error 
 		cmd.Println()
 		cmd.Println("The following tools are now available from this server:")
 		for i, tool := range tools {
-			cmd.Printf("%d. %s: %s\n\n", i+1, tool.Name, tool.Description)
+			cmd.Printf("%d. %s: %s\n\n", i+1, tool.Name, summarizeToolDescription(tool.Description))
 		}
 		printedSection = true
 	}

--- a/cmd/register_run_test.go
+++ b/cmd/register_run_test.go
@@ -102,6 +102,48 @@ func TestRunRegisterMCPServer_PrintsPromptsAndResourcesWithoutTools(t *testing.T
 	}
 }
 
+func TestPrintRegisteredServerSummary_TrimsToolDescriptions(t *testing.T) {
+	description := strings.Repeat("a", 40) + "\n\t" + strings.Repeat("b", 50)
+	wantSummary := strings.Repeat("a", 40) + " " + strings.Repeat("b", 36) + "..."
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api/v0/tools":
+			_ = json.NewEncoder(w).Encode([]*types.Tool{
+				{Name: "long-tool", Description: description},
+			})
+		case "/api/v0/prompts":
+			_ = json.NewEncoder(w).Encode([]model.Prompt{})
+		case "/api/v0/resources":
+			_ = json.NewEncoder(w).Encode([]*types.Resource{})
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	}))
+	defer server.Close()
+
+	origClient := apiClient
+	defer func() { apiClient = origClient }()
+	apiClient = client.NewClient(server.URL, "", http.DefaultClient)
+
+	cmd := &cobra.Command{}
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	registeredServer := &types.McpServer{
+		Name:      "test-server",
+		Transport: string(types.TransportStreamableHTTP),
+	}
+	if err := printRegisteredServerSummary(cmd, registeredServer); err != nil {
+		t.Fatalf("printRegisteredServerSummary returned error: %v", err)
+	}
+
+	want := "1. long-tool: " + wantSummary + "\n\n"
+	if !strings.Contains(out.String(), want) {
+		t.Fatalf("expected trimmed tool description %q, got: %s", want, out.String())
+	}
+}
+
 func TestRunRegisterMCPServer_PrintsEmptySummaryWhenNoCapabilitiesExist(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {

--- a/cmd/tool_description.go
+++ b/cmd/tool_description.go
@@ -1,0 +1,19 @@
+package cmd
+
+import "strings"
+
+const (
+	toolDescriptionSummaryLimit = 80
+	toolDescriptionEllipsis     = "..."
+)
+
+func summarizeToolDescription(description string) string {
+	summary := strings.Join(strings.Fields(description), " ")
+	runes := []rune(summary)
+	if len(runes) <= toolDescriptionSummaryLimit {
+		return summary
+	}
+
+	textLimit := toolDescriptionSummaryLimit - len(toolDescriptionEllipsis)
+	return strings.TrimSpace(string(runes[:textLimit])) + toolDescriptionEllipsis
+}

--- a/cmd/tool_description_test.go
+++ b/cmd/tool_description_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestSummarizeToolDescription(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		want        string
+	}{
+		{
+			name:        "empty",
+			description: "",
+			want:        "",
+		},
+		{
+			name:        "whitespace only",
+			description: " \n\t\r ",
+			want:        "",
+		},
+		{
+			name:        "short description",
+			description: "Find nearby places",
+			want:        "Find nearby places",
+		},
+		{
+			name:        "collapse whitespace",
+			description: "Find nearby\n\tplaces   by name",
+			want:        "Find nearby places by name",
+		},
+		{
+			name:        "exact limit",
+			description: strings.Repeat("a", toolDescriptionSummaryLimit),
+			want:        strings.Repeat("a", toolDescriptionSummaryLimit),
+		},
+		{
+			name:        "over limit",
+			description: strings.Repeat("a", toolDescriptionSummaryLimit+1),
+			want:        strings.Repeat("a", toolDescriptionSummaryLimit-len(toolDescriptionEllipsis)) + toolDescriptionEllipsis,
+		},
+		{
+			name:        "unicode remains valid",
+			description: strings.Repeat("界", toolDescriptionSummaryLimit+1),
+			want:        strings.Repeat("界", toolDescriptionSummaryLimit-len(toolDescriptionEllipsis)) + toolDescriptionEllipsis,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := summarizeToolDescription(tt.description)
+			if got != tt.want {
+				t.Fatalf("summarizeToolDescription() = %q, want %q", got, tt.want)
+			}
+			if !utf8.ValidString(got) {
+				t.Fatalf("summarizeToolDescription() returned invalid UTF-8: %q", got)
+			}
+			if utf8.RuneCountInString(got) > toolDescriptionSummaryLimit {
+				t.Fatalf("summary has %d runes, want at most %d", utf8.RuneCountInString(got), toolDescriptionSummaryLimit)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- collapse tool descriptions to a single line in `register` and `list tools`
- truncate long summaries to 80 Unicode code points with a trailing `...`
- preserve full descriptions for detailed views and add regression coverage for both CLI paths

Closes #239

## Pre-Agreement Checklist (required)

- [x] I have read and followed the [contribution guidelines](https://docs.mcpjungle.com/developers/contributing).
- [x] This PR addresses an existing issue or a concluded discussion.
- [x] If there was no existing issue/discussion, I opened one first to align with maintainers before submitting this PR.
- [x] I confirmed the issue/discussion priority with maintainers and understand low-priority items may receive limited attention.
- [x] I kept this PR focused and reasonably small; if the work is large, I split it into smaller PRs where possible.
- [x] Any AI-generated code in this PR was reviewed by a human author.

## Validation Checklist

- [ ] `go test ./...` passes locally.
- [ ] `scripts/test-mcpjungle.sh` passes locally.
- [x] I added or updated tests for new behavior where applicable.
- [x] I updated documentation for user-facing changes where applicable.

Validation completed:

- `go test ./cmd -count=1 -run 'Test(SummarizeToolDescription|PrintRegisteredServerSummary_TrimsToolDescriptions|RunListTools_TrimsToolDescriptions)$'`
- `go test ./cmd -count=1 -skip '^TestResolveTargetDirForExport$'`
- `go build ./...`
- `go vet ./...`
- `git diff --check`

The full Go suite was also attempted. Unrelated tests could not complete in this Windows environment because CGO is disabled and no C compiler is installed; client network-error tests are intercepted by the local proxy; and an existing permission test relies on Unix permission semantics. The integration script was not run because its local integration prerequisites were unavailable. No documentation update is needed for this output-only formatting change.

## Linked Context

- Issue(s): #239
- Discussion(s):
