### PR TITLE
Normalize versioned upstream OAuth endpoint URLs

### DIFF
--- a/internal/service/mcp/upstream_oauth.go
+++ b/internal/service/mcp/upstream_oauth.go
@@ -10,6 +10,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"strings"
 	"time"
 
 	mcpgoclient "github.com/mark3labs/mcp-go/client"
@@ -330,6 +332,7 @@ func (m *MCPService) bootstrapUpstreamOAuth(ctx context.Context, input *types.Re
 	if err != nil {
 		return fmt.Errorf("failed to build OAuth authorization URL: %w", err)
 	}
+	authURL = normalizeOAuthEndpointURL(authURL, input.URL, "authorize")
 
 	inputJSON, err := json.Marshal(input)
 	if err != nil {
@@ -463,22 +466,77 @@ func registerOAuthClientWithoutEmptyScope(
 	if err != nil {
 		return "", "", fmt.Errorf("failed to marshal registration request: %w", err)
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, metadata.RegistrationEndpoint, bytes.NewReader(reqBody))
+
+	endpoints := registrationEndpointCandidates(metadata.RegistrationEndpoint, input.URL)
+	var lastErr error
+
+	for _, endpoint := range endpoints {
+		clientID, clientSecret, statusCode, reqErr := registerOAuthClientAtEndpoint(ctx, endpoint, reqBody)
+		if reqErr == nil {
+			return clientID, clientSecret, nil
+		}
+		if statusCode == http.StatusForbidden {
+			return "", "", errUpstreamOAuthDCRUnsupported
+		}
+		lastErr = reqErr
+		if statusCode != http.StatusNotFound {
+			return "", "", reqErr
+		}
+	}
+
+	if lastErr != nil {
+		return "", "", lastErr
+	}
+	return "", "", fmt.Errorf("failed to dynamically register OAuth client")
+}
+
+func registrationEndpointCandidates(registrationEndpoint, upstreamURL string) []string {
+	seen := map[string]struct{}{}
+	add := func(candidate string, out *[]string) {
+		if candidate == "" {
+			return
+		}
+		if _, ok := seen[candidate]; ok {
+			return
+		}
+		seen[candidate] = struct{}{}
+		*out = append(*out, candidate)
+	}
+
+	candidates := make([]string, 0, 4)
+	add(registrationEndpoint, &candidates)
+	add(strings.TrimRight(registrationEndpoint, "/"), &candidates)
+
+	upstreamParsed, err := url.Parse(upstreamURL)
+	if err == nil && upstreamParsed.Scheme != "" && upstreamParsed.Host != "" {
+		segments := strings.Split(strings.Trim(upstreamParsed.Path, "/"), "/")
+		if len(segments) > 0 && segments[0] != "" {
+			base := *upstreamParsed
+			base.Path = "/" + segments[0] + "/register"
+			base.RawQuery = ""
+			base.Fragment = ""
+			add(base.String(), &candidates)
+		}
+	}
+
+	return candidates
+}
+
+func registerOAuthClientAtEndpoint(ctx context.Context, endpoint string, reqBody []byte) (string, string, int, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader(reqBody))
 	if err != nil {
-		return "", "", fmt.Errorf("failed to create registration request: %w", err)
+		return "", "", 0, fmt.Errorf("failed to create registration request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return "", "", fmt.Errorf("failed to send registration request: %w", err)
+		return "", "", 0, fmt.Errorf("failed to send registration request: %w", err)
 	}
 	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusCreated && resp.StatusCode != http.StatusOK {
-		if resp.StatusCode == http.StatusForbidden {
-			return "", "", errUpstreamOAuthDCRUnsupported
-		}
 		body, _ := io.ReadAll(resp.Body)
 		var oauthErr struct {
 			Error            string `json:"error"`
@@ -486,11 +544,11 @@ func registerOAuthClientWithoutEmptyScope(
 		}
 		if err := json.Unmarshal(body, &oauthErr); err == nil && oauthErr.Error != "" {
 			if oauthErr.ErrorDescription != "" {
-				return "", "", fmt.Errorf("OAuth error: %s - %s", oauthErr.Error, oauthErr.ErrorDescription)
+				return "", "", resp.StatusCode, fmt.Errorf("OAuth error: %s - %s", oauthErr.Error, oauthErr.ErrorDescription)
 			}
-			return "", "", fmt.Errorf("OAuth error: %s", oauthErr.Error)
+			return "", "", resp.StatusCode, fmt.Errorf("OAuth error: %s", oauthErr.Error)
 		}
-		return "", "", fmt.Errorf("registration request failed with status %d: %s", resp.StatusCode, body)
+		return "", "", resp.StatusCode, fmt.Errorf("registration request failed with status %d: %s", resp.StatusCode, body)
 	}
 
 	var regResponse struct {
@@ -498,9 +556,201 @@ func registerOAuthClientWithoutEmptyScope(
 		ClientSecret string `json:"client_secret,omitempty"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&regResponse); err != nil {
-		return "", "", fmt.Errorf("failed to decode registration response: %w", err)
+		return "", "", resp.StatusCode, fmt.Errorf("failed to decode registration response: %w", err)
 	}
-	return regResponse.ClientID, regResponse.ClientSecret, nil
+
+	return regResponse.ClientID, regResponse.ClientSecret, resp.StatusCode, nil
+}
+
+func normalizeOAuthEndpointURL(endpointURL, upstreamURL, endpointName string) string {
+	if endpointURL == "" {
+		return deriveVersionedOAuthEndpoint(upstreamURL, endpointName)
+	}
+
+	parsedEndpoint, err := url.Parse(endpointURL)
+	if err != nil || parsedEndpoint.Scheme == "" || parsedEndpoint.Host == "" {
+		return endpointURL
+	}
+
+	versionSegment := discoverVersionSegment(upstreamURL)
+	if versionSegment == "" {
+		return endpointURL
+	}
+
+	endpointPath := strings.Trim(parsedEndpoint.Path, "/")
+	parts := strings.Split(endpointPath, "/")
+	if len(parts) == 1 {
+		if parts[0] == endpointName {
+			parsedEndpoint.Path = "/" + versionSegment + "/" + endpointName
+			return parsedEndpoint.String()
+		}
+	}
+	if len(parts) == 2 && parts[0] == versionSegment {
+		return endpointURL
+	}
+
+	return endpointURL
+}
+
+func discoverVersionSegment(upstreamURL string) string {
+	parsed, err := url.Parse(upstreamURL)
+	if err != nil {
+		return ""
+	}
+	segments := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+	candidate := segments[0]
+	if len(candidate) >= 2 && strings.HasPrefix(candidate, "v") {
+		allDigits := true
+		for _, r := range candidate[1:] {
+			if r < '0' || r > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			return candidate
+		}
+	}
+	return ""
+}
+
+func deriveVersionedOAuthEndpoint(upstreamURL, endpointName string) string {
+	parsed, err := url.Parse(upstreamURL)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return ""
+	}
+	versionSegment := discoverVersionSegment(upstreamURL)
+	if versionSegment == "" {
+		return ""
+	}
+	parsed.Path = "/" + versionSegment + "/" + endpointName
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+func discoverOAuthResourceIndicator(ctx context.Context, upstreamURL string) string {
+	resourceURL := strings.TrimSpace(upstreamURL)
+	if resourceURL == "" {
+		return ""
+	}
+
+	parsedResource, err := url.Parse(resourceURL)
+	if err != nil || parsedResource.Scheme == "" || parsedResource.Host == "" {
+		return ""
+	}
+	parsedResource.RawQuery = ""
+	parsedResource.Fragment = ""
+	resourceURL = parsedResource.String()
+
+	metadataPath := "/.well-known/oauth-protected-resource" + ensureLeadingSlash(strings.TrimSuffix(parsedResource.Path, "/"))
+	metadataURL := parsedResource.Scheme + "://" + parsedResource.Host + metadataPath
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
+	if err != nil {
+		return resourceURL
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return resourceURL
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return resourceURL
+	}
+
+	var metadata struct {
+		Resource string `json:"resource"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&metadata); err != nil {
+		return resourceURL
+	}
+
+	candidate := strings.TrimSpace(metadata.Resource)
+	if candidate == "" {
+		return resourceURL
+	}
+
+	parsedCandidate, err := url.Parse(candidate)
+	if err != nil || parsedCandidate.Scheme == "" || parsedCandidate.Host == "" {
+		return resourceURL
+	}
+	parsedCandidate.RawQuery = ""
+	parsedCandidate.Fragment = ""
+	return parsedCandidate.String()
+}
+
+func ensureLeadingSlash(path string) string {
+	if path == "" {
+		return ""
+	}
+	if strings.HasPrefix(path, "/") {
+		return path
+	}
+	return "/" + path
+}
+
+func exchangeAuthorizationCodeForToken(ctx context.Context, tokenEndpoint, clientID, clientSecret, redirectURI, codeVerifier, code, resource string) (*mcpgotransport.Token, error) {
+	form := url.Values{}
+	form.Set("grant_type", "authorization_code")
+	form.Set("code", code)
+	form.Set("redirect_uri", redirectURI)
+	form.Set("code_verifier", codeVerifier)
+	if clientID != "" {
+		form.Set("client_id", clientID)
+	}
+	if clientSecret != "" {
+		form.Set("client_secret", clientSecret)
+	}
+	if resource != "" {
+		form.Set("resource", resource)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, tokenEndpoint, strings.NewReader(form.Encode()))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to send token request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("token request failed with status %d: %s", resp.StatusCode, body)
+	}
+
+	var payload struct {
+		AccessToken  string `json:"access_token"`
+		TokenType    string `json:"token_type"`
+		RefreshToken string `json:"refresh_token,omitempty"`
+		Scope        string `json:"scope,omitempty"`
+		ExpiresIn    int64  `json:"expires_in,omitempty"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return nil, fmt.Errorf("failed to decode token response: %w", err)
+	}
+	if payload.AccessToken == "" {
+		return nil, fmt.Errorf("token response missing access_token")
+	}
+
+	token := &mcpgotransport.Token{
+		AccessToken:  payload.AccessToken,
+		TokenType:    payload.TokenType,
+		RefreshToken: payload.RefreshToken,
+		Scope:        payload.Scope,
+	}
+	if payload.ExpiresIn > 0 {
+		token.ExpiresAt = time.Now().Add(time.Duration(payload.ExpiresIn) * time.Second)
+	}
+	return token, nil
 }
 
 func joinScopes(scopes []string) string {
@@ -700,9 +950,29 @@ func (m *MCPService) processOAuthAuthorizationCode(ctx context.Context, server *
 		return fmt.Errorf("failed to retrieve OAuth handler for upstream server")
 	}
 
-	oauthErr.Handler.SetExpectedState(state)
-	if err := oauthErr.Handler.ProcessAuthorizationResponse(ctx, code, state, codeVerifier); err != nil {
+	rawTokenEndpoint := ""
+	if metadata, err := oauthErr.Handler.GetServerMetadata(ctx); err == nil {
+		rawTokenEndpoint = metadata.TokenEndpoint
+	}
+	tokenEndpoint := normalizeOAuthEndpointURL(rawTokenEndpoint, input.URL, "token")
+	if tokenEndpoint == "" || tokenEndpoint == rawTokenEndpoint {
+		oauthErr.Handler.SetExpectedState(state)
+		if err := oauthErr.Handler.ProcessAuthorizationResponse(ctx, code, state, codeVerifier); err != nil {
+			return fmt.Errorf("failed to exchange OAuth authorization code for token: %w", err)
+		}
+		return nil
+	}
+
+	resourceIndicator := discoverOAuthResourceIndicator(ctx, input.URL)
+	token, err := exchangeAuthorizationCodeForToken(ctx, tokenEndpoint, input.OAuthClientID, input.OAuthClientSecret, input.OAuthRedirectURI, codeVerifier, code, resourceIndicator)
+	if err != nil {
+		// Do not retry token exchange with the same authorization code via handler flow.
+		// Authorization codes are often single-use and may already be invalidated.
 		return fmt.Errorf("failed to exchange OAuth authorization code for token: %w", err)
+	}
+
+	if err := tokenStore.SaveToken(ctx, token); err != nil {
+		return fmt.Errorf("failed to persist OAuth token: %w", err)
 	}
 
 	return nil

--- a/internal/service/mcp/upstream_oauth_test.go
+++ b/internal/service/mcp/upstream_oauth_test.go
@@ -23,10 +23,16 @@ import (
 )
 
 type mockOAuthUpstream struct {
-	server           *httptest.Server
-	accessToken      string
-	registerCalls    int
-	lastRegisterBody map[string]any
+	server                     *httptest.Server
+	accessToken                string
+	registerCalls              int
+	lastRegisterBody           map[string]any
+	tokenCalls                 int
+	v1TokenCalls               int
+	lastTokenForm              url.Values
+	lastV1TokenForm            url.Values
+	expectedV1TokenResource    string
+	forceV1TokenFailure        bool
 }
 
 func newMockOAuthUpstream(t *testing.T) *mockOAuthUpstream {
@@ -49,6 +55,13 @@ func newMockOAuthUpstream(t *testing.T) *mockOAuthUpstream {
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"authorization_servers": []string{mock.server.URL},
 			"resource":              mock.server.URL + "/mcp",
+		})
+	})
+
+	mux.HandleFunc("/.well-known/oauth-protected-resource/v1/mcp", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"authorization_servers": []string{mock.server.URL},
+			"resource":              mock.server.URL + "/v1/mcp",
 		})
 	})
 
@@ -92,6 +105,34 @@ func newMockOAuthUpstream(t *testing.T) *mockOAuthUpstream {
 
 	mux.HandleFunc("/token", func(w http.ResponseWriter, r *http.Request) {
 		require.NoError(t, r.ParseForm())
+		mock.tokenCalls++
+		mock.lastTokenForm = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  mock.accessToken,
+			"token_type":    "Bearer",
+			"refresh_token": "mock-refresh-token",
+			"expires_in":    3600,
+			"scope":         "mcp.read",
+		})
+	})
+
+	mux.HandleFunc("/v1/token", func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		mock.v1TokenCalls++
+		mock.lastV1TokenForm = r.PostForm
+		if mock.expectedV1TokenResource != "" {
+			require.Equal(t, mock.expectedV1TokenResource, r.PostForm.Get("resource"))
+		}
+		if mock.forceV1TokenFailure {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusBadRequest)
+			_ = json.NewEncoder(w).Encode(map[string]any{
+				"error":             "invalid_request",
+				"error_description": "mock failure",
+			})
+			return
+		}
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]any{
 			"access_token":  mock.accessToken,
@@ -103,6 +144,15 @@ func newMockOAuthUpstream(t *testing.T) *mockOAuthUpstream {
 	})
 
 	mux.Handle("/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer "+mock.accessToken {
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte("unauthorized"))
+			return
+		}
+		streamable.ServeHTTP(w, r)
+	}))
+
+	mux.Handle("/v1/mcp", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.Header.Get("Authorization") != "Bearer "+mock.accessToken {
 			w.WriteHeader(http.StatusUnauthorized)
 			_, _ = w.Write([]byte("unauthorized"))
@@ -432,4 +482,158 @@ func TestDeregisterMcpServer_HardDeletesUpstreamOAuthState(t *testing.T) {
 	var pendingCount int64
 	require.NoError(t, setup.DB.Unscoped().Model(&model.UpstreamOAuthPendingSession{}).Where("server_name = ?", "todoist").Count(&pendingCount).Error)
 	require.Zero(t, pendingCount)
+}
+
+func TestRegistrationEndpointCandidates_IncludesVersionedFallback(t *testing.T) {
+	t.Parallel()
+
+	candidates := registrationEndpointCandidates(
+		"https://mcp.atlassian.com/register/",
+		"https://mcp.atlassian.com/v1/mcp",
+	)
+
+	require.Contains(t, candidates, "https://mcp.atlassian.com/register/")
+	require.Contains(t, candidates, "https://mcp.atlassian.com/register")
+	require.Contains(t, candidates, "https://mcp.atlassian.com/v1/register")
+}
+
+func TestNormalizeOAuthEndpointURL_UsesUpstreamVersionPrefix(t *testing.T) {
+	t.Parallel()
+
+	authorizeURL := normalizeOAuthEndpointURL(
+		"https://mcp.atlassian.com/authorize?client_id=test",
+		"https://mcp.atlassian.com/v1/mcp",
+		"authorize",
+	)
+	require.Equal(t, "https://mcp.atlassian.com/v1/authorize?client_id=test", authorizeURL)
+
+	tokenURL := normalizeOAuthEndpointURL(
+		"https://mcp.atlassian.com/token",
+		"https://mcp.atlassian.com/v1/mcp",
+		"token",
+	)
+	require.Equal(t, "https://mcp.atlassian.com/v1/token", tokenURL)
+}
+
+func TestDiscoverOAuthResourceIndicator_UsesProtectedResourceMetadata(t *testing.T) {
+	t.Parallel()
+
+	const expectedResource = "https://provider.example.com/mcp"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/.well-known/oauth-protected-resource/mcp", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]any{"resource": expectedResource})
+	}))
+	t.Cleanup(server.Close)
+
+	resource := discoverOAuthResourceIndicator(context.Background(), server.URL+"/mcp")
+	require.Equal(t, expectedResource, resource)
+}
+
+func TestExchangeAuthorizationCodeForToken_IncludesResourceParam(t *testing.T) {
+	t.Parallel()
+
+	const expectedResource = "https://provider.example.com/mcp"
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, http.MethodPost, r.Method)
+		require.NoError(t, r.ParseForm())
+		require.Equal(t, expectedResource, r.Form.Get("resource"))
+		require.Equal(t, "authorization_code", r.Form.Get("grant_type"))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "token",
+			"token_type":    "Bearer",
+			"refresh_token": "refresh",
+			"expires_in":    3600,
+		})
+	}))
+	t.Cleanup(server.Close)
+
+	token, err := exchangeAuthorizationCodeForToken(
+		context.Background(),
+		server.URL,
+		"client-id",
+		"client-secret",
+		"http://localhost/callback",
+		"pkce-verifier",
+		"auth-code",
+		expectedResource,
+	)
+	require.NoError(t, err)
+	require.Equal(t, "token", token.AccessToken)
+}
+
+func TestProcessOAuthAuthorizationCode_ManualBranchIncludesResource(t *testing.T) {
+	t.Parallel()
+
+	service, setup := newOAuthCapableService(t)
+	upstream := newMockOAuthUpstream(t)
+	upstream.expectedV1TokenResource = upstream.server.URL + "/v1/mcp"
+
+	server := newOAuthHTTPServerModel(t, upstream.server.URL+"/v1/mcp")
+	require.NoError(t, setup.DB.Create(server).Error)
+
+	input := &types.RegisterServerInput{
+		Name:             "todoist",
+		Description:      "OAuth upstream",
+		Transport:        string(types.TransportStreamableHTTP),
+		URL:              upstream.server.URL + "/v1/mcp",
+		OAuthRedirectURI: "http://127.0.0.1:9999/oauth/callback",
+		OAuthClientID:    "mock-client-id",
+		OAuthScopes:      []string{"mcp.read"},
+	}
+
+	err := service.processOAuthAuthorizationCode(
+		context.Background(),
+		server,
+		input,
+		"test-code-verifier",
+		"expected-state",
+		"mock-auth-code",
+	)
+	require.NoError(t, err)
+	require.Equal(t, 1, upstream.v1TokenCalls)
+	require.Equal(t, 0, upstream.tokenCalls)
+	require.Equal(t, upstream.server.URL+"/v1/mcp", upstream.lastV1TokenForm.Get("resource"))
+
+	stored, err := getStoredUpstreamOAuthToken(setup.DB, "todoist")
+	require.NoError(t, err)
+	require.Equal(t, upstream.accessToken, stored.AccessToken)
+}
+
+func TestProcessOAuthAuthorizationCode_ManualFailureDoesNotRetryHandlerFlow(t *testing.T) {
+	t.Parallel()
+
+	service, setup := newOAuthCapableService(t)
+	upstream := newMockOAuthUpstream(t)
+	upstream.forceV1TokenFailure = true
+
+	server := newOAuthHTTPServerModel(t, upstream.server.URL+"/v1/mcp")
+	require.NoError(t, setup.DB.Create(server).Error)
+
+	input := &types.RegisterServerInput{
+		Name:             "todoist",
+		Description:      "OAuth upstream",
+		Transport:        string(types.TransportStreamableHTTP),
+		URL:              upstream.server.URL + "/v1/mcp",
+		OAuthRedirectURI: "http://127.0.0.1:9999/oauth/callback",
+		OAuthClientID:    "mock-client-id",
+		OAuthScopes:      []string{"mcp.read"},
+	}
+
+	err := service.processOAuthAuthorizationCode(
+		context.Background(),
+		server,
+		input,
+		"test-code-verifier",
+		"expected-state",
+		"mock-auth-code",
+	)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "failed to exchange OAuth authorization code for token")
+	require.Equal(t, 1, upstream.v1TokenCalls)
+	require.Equal(t, 0, upstream.tokenCalls)
+
+	_, lookupErr := getStoredUpstreamOAuthToken(setup.DB, "todoist")
+	require.Error(t, lookupErr)
 }


### PR DESCRIPTION
Some upstream MCP servers return OAuth metadata endpoints (authorize/token/register) without the version prefix present in their actual routes, causing OAuth registration to fail with 404s.

Add normalizeOAuthEndpointURL/discoverVersionSegment to rewrite bare endpoints using the upstream URL's version segment, retry dynamic client registration across versioned candidate endpoints, and exchange authorization codes via the normalized token endpoint with a fallback to the existing handler-based flow.

## Summary

<!-- Briefly explain what this PR changes and why. -->

## Pre-Agreement Checklist (required)

Please check all boxes before requesting review:

- [x] I have read and followed the [contribution guidelines](https://docs.mcpjungle.com/developers/contributing).
- [x] This PR addresses an existing issue or a concluded discussion.
- [x] If there was no existing issue/discussion, I opened one first to align with maintainers before submitting this PR.
- [ ] I confirmed the issue/discussion priority with maintainers and understand low-priority items may receive limited attention.
- [x] I kept this PR focused and reasonably small; if the work is large, I split it into smaller PRs where possible.
- [x] Any AI-generated code in this PR was reviewed by a human author.

## Validation Checklist

- [x] `go test ./...` passes locally.
- [x] `scripts/test-mcpjungle.sh` passes locally.
- [x] I added or updated tests for new behavior where applicable.
- [x] I updated documentation for user-facing changes where applicable.

## Linked Context

- Issue(s): <!-- e.g., #123 -->
- Discussion(s): <!-- e.g., https://github.com/mcpjungle/MCPJungle/discussions/456 -->


Closes #292
