### PR TITLE
feat(cli): support OS keychain secret references

### DIFF
--- a/cmd/create.go
+++ b/cmd/create.go
@@ -307,8 +307,8 @@ func readToolGroupConfig(filePath string) (*types.ToolGroup, error) {
 	if err := json.Unmarshal(data, &input); err != nil {
 		return &input, fmt.Errorf("failed to parse config file: %w", err)
 	}
-	if err := configresolver.ResolveEnvVars(&input); err != nil {
-		return &input, fmt.Errorf("failed to resolve config file environment variables: %w", err)
+	if err := configresolver.ResolveConfig(&input); err != nil {
+		return &input, fmt.Errorf("failed to resolve config file secrets: %w", err)
 	}
 
 	return &input, nil
@@ -325,8 +325,8 @@ func readMcpClientConfig(filePath string) (*types.McpClientConfig, error) {
 	if err := json.Unmarshal(data, &input); err != nil {
 		return &input, fmt.Errorf("failed to parse config file: %w", err)
 	}
-	if err := configresolver.ResolveEnvVars(&input); err != nil {
-		return &input, fmt.Errorf("failed to resolve config file environment variables: %w", err)
+	if err := configresolver.ResolveConfig(&input); err != nil {
+		return &input, fmt.Errorf("failed to resolve config file secrets: %w", err)
 	}
 
 	return &input, nil
@@ -343,8 +343,8 @@ func readUserConfig(filePath string) (*types.UserConfig, error) {
 	if err := json.Unmarshal(data, &input); err != nil {
 		return &input, fmt.Errorf("failed to parse config file: %w", err)
 	}
-	if err := configresolver.ResolveEnvVars(&input); err != nil {
-		return &input, fmt.Errorf("failed to resolve config file environment variables: %w", err)
+	if err := configresolver.ResolveConfig(&input); err != nil {
+		return &input, fmt.Errorf("failed to resolve config file secrets: %w", err)
 	}
 
 	return &input, nil

--- a/cmd/register.go
+++ b/cmd/register.go
@@ -200,8 +200,8 @@ func readMcpServerConfig(filePath string) (types.RegisterServerInput, error) {
 	if err := json.Unmarshal(data, &input); err != nil {
 		return input, fmt.Errorf("failed to parse config file: %w", err)
 	}
-	if err := configresolver.ResolveEnvVars(&input); err != nil {
-		return input, fmt.Errorf("failed to resolve config file environment variables: %w", err)
+	if err := configresolver.ResolveConfig(&input); err != nil {
+		return input, fmt.Errorf("failed to resolve config file secrets: %w", err)
 	}
 
 	return input, nil

--- a/docs/reference/config-file.mdx
+++ b/docs/reference/config-file.mdx
@@ -65,11 +65,14 @@ For the enterprise bootstrap flow and login workflow, see [Enterprise operations
 
 Several `mcpjungle` commands accept a `-c` / `--conf` flag pointing to a JSON file instead of inline CLI flags. This section documents every supported JSON format.
 
-### `${VAR_NAME}` placeholder substitution
+### Secret placeholder substitution
 
-All JSON config files support environment variable placeholders in string fields. Before sending the request to the server, the CLI expands every `${VAR_NAME}` occurrence using the current shell environment.
+All JSON config files support environment variable and OS keychain placeholders in string fields. Before sending the request to the server, the CLI expands each placeholder locally.
+
+#### Environment variables
 
 Rules:
+
 - Only `${VAR_NAME}` syntax is recognized — not `$VAR_NAME`.
 - Placeholders can appear anywhere inside a string, including as a substring: `"prefix-${VAR}-suffix"`.
 - Substitution runs in the CLI process, so the variable must be set in the environment where you run the command.
@@ -84,6 +87,66 @@ Rules:
   "bearer_token": "${API_TOKEN}"
 }
 ```
+
+#### OS keychain secrets
+
+Use `${keychain:<key>}` to read a secret from the native credential store. The key becomes the credential's service name. The account defaults to the current username from `$USER`, or the equivalent current OS username when `$USER` is unavailable.
+
+For example, `${keychain:github-token}` reads the credential whose service is `github-token` and whose account is your current username:
+
+```json
+{
+  "name": "github",
+  "transport": "stdio",
+  "command": "npx",
+  "args": ["-y", "@modelcontextprotocol/server-github"],
+  "env": {
+    "GITHUB_PERSONAL_ACCESS_TOKEN": "${keychain:github-token}"
+  }
+}
+```
+
+Store the matching credential with your platform's credential tool.
+
+<Tabs>
+  <Tab title="macOS">
+    ```bash
+    security add-generic-password -U \
+      -a "$USER" \
+      -s github-token \
+      -w
+    ```
+
+    Keep `-w` as the final option so `security` prompts for the secret without placing it in your shell history.
+  </Tab>
+  <Tab title="Linux">
+    Linux requires a Secret Service-compatible keyring, such as GNOME Keyring. Store the secret with `secret-tool`:
+
+    ```bash
+    secret-tool store \
+      --label="MCPJungle GitHub token" \
+      service github-token \
+      username "$USER"
+    ```
+
+    `secret-tool` prompts for the secret value.
+  </Tab>
+  <Tab title="Windows">
+    In PowerShell, `cmdkey` stores the credential under the combined `<service>:<account>` target expected by the keyring backend:
+
+    ```powershell
+    cmdkey /generic:"github-token:$env:USERNAME" /user:"$env:USERNAME"
+    ```
+
+    `cmdkey` prompts for the secret when `/pass` is omitted.
+  </Tab>
+</Tabs>
+
+Keychain placeholders follow the same interpolation rules as environment variables. They work in nested objects, string arrays, headers, bearer tokens, and strings containing multiple placeholders. Missing credentials, unavailable keychain backends, and unsupported provider names cause configuration resolution to fail before the request is submitted.
+
+<Warning>
+  Keychain resolution protects the secret at rest on your local machine, but it does not provide end-to-end secret-reference semantics. The CLI sends the resolved plaintext value to the MCPJungle server, where it may be persisted just like an interpolated environment variable.
+</Warning>
 
 ### Register a Streamable HTTP server
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/spf13/afero v1.15.0
 	github.com/spf13/cobra v1.9.1
 	github.com/stretchr/testify v1.11.1
+	github.com/zalando/go-keyring v0.2.8
 	go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.63.0
 	go.opentelemetry.io/otel v1.38.0
 	go.opentelemetry.io/otel/exporters/prometheus v0.43.0
@@ -32,6 +33,7 @@ require (
 	github.com/bytedance/sonic/loader v0.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/cloudwego/base64x v0.1.6 // indirect
+	github.com/danieljoos/wincred v1.2.3 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.10 // indirect
@@ -44,6 +46,7 @@ require (
 	github.com/go-playground/validator/v10 v10.27.0 // indirect
 	github.com/go-sql-driver/mysql v1.8.1 // indirect
 	github.com/goccy/go-json v0.10.5 // indirect
+	github.com/godbus/dbus/v5 v5.2.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/jsonschema-go v0.4.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,8 @@ github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/cloudwego/base64x v0.1.6 h1:t11wG9AECkCDk5fMSoxmufanudBtJ+/HemLstXDLI2M=
 github.com/cloudwego/base64x v0.1.6/go.mod h1:OFcloc187FXDaYHvrNIjxSe8ncn0OOM8gEHfghB2IPU=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -46,6 +48,8 @@ github.com/go-sql-driver/mysql v1.8.1 h1:LedoTUt/eveggdHS9qUFC1EFSa8bU2+1pZjSRpv
 github.com/go-sql-driver/mysql v1.8.1/go.mod h1:wEBSXgmK//2ZFJyE+qWnIsVGmvmEKlqwuVSjsCm7DZg=
 github.com/goccy/go-json v0.10.5 h1:Fq85nIqj+gXn/S5ahsiTlK3TmC85qgirsdTP/+DeaC4=
 github.com/goccy/go-json v0.10.5/go.mod h1:oq7eo15ShAhp70Anwd5lgX2pLfOS3QCiwU/PULtXL6M=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9 h1:au07oEsX2xN0ktxqI+Sida1w446QrXBRJ0nee3SNZlA=
 github.com/golang-sql/civil v0.0.0-20220223132316-b832511892a9/go.mod h1:8vg3r2VgvsThLBIFL93Qb5yWzgyZWhEmBwUJWevAkK0=
 github.com/golang-sql/sqlexp v0.1.0 h1:ZCD6MBpcuOVfGVqsEmY5/4FtYiKz6tSyUv9LPEDei6A=
@@ -136,6 +140,8 @@ github.com/spf13/pflag v1.0.6/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
+github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
@@ -149,6 +155,8 @@ github.com/ugorji/go/codec v1.3.0 h1:Qd2W2sQawAfG8XSvzwhBeoGq71zXOC/Q1E9y/wUcsUA
 github.com/ugorji/go/codec v1.3.0/go.mod h1:pRBVtBSKl77K30Bv8R2P+cLSGaTtex6fsA2Wjqmfxj4=
 github.com/yosida95/uritemplate/v3 v3.0.2 h1:Ed3Oyj9yrmi9087+NczuL5BwkIc4wvTb5zIM+UJPGz4=
 github.com/yosida95/uritemplate/v3 v3.0.2/go.mod h1:ILOh0sOhIJR3+L/8afwt/kE++YT040gmv5BQTMR2HP4=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=
 go.opentelemetry.io/auto/sdk v1.1.0/go.mod h1:3wSPjt5PWp2RhlCcmmOial7AvC4DQqZb7a7wCow3W8A=
 go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin v0.63.0 h1:5kSIJ0y8ckZZKoDhZHdVtcyjVi6rXyAwyaR8mp4zLbg=

--- a/internal/configresolver/config_resolver.go
+++ b/internal/configresolver/config_resolver.go
@@ -8,13 +8,46 @@ import (
 )
 
 const (
-	envVarPlaceholderStart = "${"
-	envVarPlaceholderEnd   = "}"
+	placeholderStart = "${"
+	placeholderEnd   = "}"
 )
 
-// ResolveEnvVars walks a configuration object recursively and resolves ${VAR}
-// placeholders in string values using the current process environment.
+// SecretProvider resolves a secret identified by an opaque key.
+type SecretProvider interface {
+	Resolve(key string) (string, error)
+}
+
+// Resolver expands environment variables and named secret-provider references.
+type Resolver struct {
+	environment SecretProvider
+	providers   map[string]SecretProvider
+}
+
+// NewResolver creates a resolver with the supplied named secret providers.
+// Environment variable interpolation is always available through ${VAR}.
+func NewResolver(providers map[string]SecretProvider) *Resolver {
+	return &Resolver{
+		environment: envProvider{},
+		providers:   providers,
+	}
+}
+
+// ResolveConfig resolves all supported placeholders in a configuration object.
+func ResolveConfig(target any) error {
+	return NewResolver(map[string]SecretProvider{
+		"keychain": newKeychainProvider(),
+	}).Resolve(target)
+}
+
+// ResolveEnvVars is retained for callers that only need the legacy ${VAR}
+// behavior. It also resolves named secret-provider references.
 func ResolveEnvVars(target any) error {
+	return ResolveConfig(target)
+}
+
+// Resolve walks a configuration object recursively and expands placeholders in
+// every string value.
+func (r *Resolver) Resolve(target any) error {
 	if target == nil {
 		return fmt.Errorf("config target must be a non-nil pointer")
 	}
@@ -24,10 +57,10 @@ func ResolveEnvVars(target any) error {
 		return fmt.Errorf("config target must be a non-nil pointer")
 	}
 
-	return resolveConfigValue(value)
+	return r.resolveConfigValue(value)
 }
 
-func resolveConfigValue(value reflect.Value) error {
+func (r *Resolver) resolveConfigValue(value reflect.Value) error {
 	if !value.IsValid() {
 		return nil
 	}
@@ -38,7 +71,7 @@ func resolveConfigValue(value reflect.Value) error {
 		if value.IsNil() {
 			return nil
 		}
-		return resolveConfigValue(value.Elem())
+		return r.resolveConfigValue(value.Elem())
 	case reflect.Interface:
 		if value.IsNil() {
 			return nil
@@ -46,7 +79,7 @@ func resolveConfigValue(value reflect.Value) error {
 
 		// Interface values are not directly writable, so resolve a cloned value and
 		// replace the interface payload with the resolved copy.
-		resolved, err := cloneAndResolveValue(value.Elem())
+		resolved, err := r.cloneAndResolveValue(value.Elem())
 		if err != nil {
 			return err
 		}
@@ -62,7 +95,7 @@ func resolveConfigValue(value reflect.Value) error {
 			if !field.CanSet() {
 				continue
 			}
-			if err := resolveConfigValue(field); err != nil {
+			if err := r.resolveConfigValue(field); err != nil {
 				return err
 			}
 		}
@@ -74,7 +107,7 @@ func resolveConfigValue(value reflect.Value) error {
 
 		// Only string values are expanded. Other scalar types are intentionally
 		// left unchanged to keep resolution predictable.
-		resolved, err := expandEnvPlaceholders(value.String())
+		resolved, err := r.expandPlaceholders(value.String())
 		if err != nil {
 			return err
 		}
@@ -82,7 +115,7 @@ func resolveConfigValue(value reflect.Value) error {
 		return nil
 	case reflect.Slice, reflect.Array:
 		for i := range value.Len() {
-			if err := resolveConfigValue(value.Index(i)); err != nil {
+			if err := r.resolveConfigValue(value.Index(i)); err != nil {
 				return err
 			}
 		}
@@ -95,7 +128,7 @@ func resolveConfigValue(value reflect.Value) error {
 		// Map entries are not addressable through reflection, so resolve each value
 		// through a writable clone and write it back under the same key.
 		for _, key := range value.MapKeys() {
-			resolved, err := cloneAndResolveValue(value.MapIndex(key))
+			resolved, err := r.cloneAndResolveValue(value.MapIndex(key))
 			if err != nil {
 				return err
 			}
@@ -107,7 +140,7 @@ func resolveConfigValue(value reflect.Value) error {
 	}
 }
 
-func cloneAndResolveValue(value reflect.Value) (reflect.Value, error) {
+func (r *Resolver) cloneAndResolveValue(value reflect.Value) (reflect.Value, error) {
 	if !value.IsValid() {
 		return value, nil
 	}
@@ -117,18 +150,18 @@ func cloneAndResolveValue(value reflect.Value) (reflect.Value, error) {
 	clone := reflect.New(value.Type()).Elem()
 	clone.Set(value)
 
-	if err := resolveConfigValue(clone); err != nil {
+	if err := r.resolveConfigValue(clone); err != nil {
 		return reflect.Value{}, err
 	}
 
 	return clone, nil
 }
 
-func expandEnvPlaceholders(input string) (string, error) {
+func (r *Resolver) expandPlaceholders(input string) (string, error) {
 	var builder strings.Builder
 
 	for cursor := 0; cursor < len(input); {
-		start := strings.Index(input[cursor:], envVarPlaceholderStart)
+		start := strings.Index(input[cursor:], placeholderStart)
 		if start == -1 {
 			builder.WriteString(input[cursor:])
 			return builder.String(), nil
@@ -139,20 +172,20 @@ func expandEnvPlaceholders(input string) (string, error) {
 
 		// Only the explicit ${VAR} form is supported. We do not inherit broader
 		// shell expansion semantics such as bare $VAR or default expressions.
-		end := strings.Index(input[start+len(envVarPlaceholderStart):], envVarPlaceholderEnd)
+		end := strings.Index(input[start+len(placeholderStart):], placeholderEnd)
 		if end == -1 {
-			return "", fmt.Errorf("invalid environment variable placeholder in %q", input)
+			return "", fmt.Errorf("invalid configuration placeholder in %q", input)
 		}
 
-		end += start + len(envVarPlaceholderStart)
-		varName := input[start+len(envVarPlaceholderStart) : end]
-		if varName == "" || strings.Contains(varName, envVarPlaceholderStart) {
-			return "", fmt.Errorf("invalid environment variable placeholder in %q", input)
+		end += start + len(placeholderStart)
+		expression := input[start+len(placeholderStart) : end]
+		if expression == "" || strings.Contains(expression, placeholderStart) {
+			return "", fmt.Errorf("invalid configuration placeholder in %q", input)
 		}
 
-		value, ok := os.LookupEnv(varName)
-		if !ok {
-			return "", fmt.Errorf("environment variable %s is not set", varName)
+		value, err := r.resolveExpression(expression)
+		if err != nil {
+			return "", err
 		}
 
 		builder.WriteString(value)
@@ -160,4 +193,31 @@ func expandEnvPlaceholders(input string) (string, error) {
 	}
 
 	return builder.String(), nil
+}
+
+func (r *Resolver) resolveExpression(expression string) (string, error) {
+	providerName, key, hasProvider := strings.Cut(expression, ":")
+	if !hasProvider {
+		return r.environment.Resolve(expression)
+	}
+	if providerName == "" || key == "" {
+		return "", fmt.Errorf("invalid secret reference %q", expression)
+	}
+
+	provider, ok := r.providers[providerName]
+	if !ok {
+		return "", fmt.Errorf("unsupported secret provider %q", providerName)
+	}
+
+	return provider.Resolve(key)
+}
+
+type envProvider struct{}
+
+func (envProvider) Resolve(key string) (string, error) {
+	value, ok := os.LookupEnv(key)
+	if !ok {
+		return "", fmt.Errorf("environment variable %s is not set", key)
+	}
+	return value, nil
 }

--- a/internal/configresolver/config_resolver_test.go
+++ b/internal/configresolver/config_resolver_test.go
@@ -1,6 +1,7 @@
 package configresolver
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -40,13 +41,84 @@ func TestExpandEnvPlaceholders(t *testing.T) {
 		{
 			name:    "invalid placeholder",
 			input:   "${MCPJ_TEST_TOKEN",
-			wantErr: "invalid environment variable placeholder",
+			wantErr: "invalid configuration placeholder",
+		},
+	}
+	resolver := NewResolver(nil)
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := resolver.expandPlaceholders(tc.input)
+			if tc.wantErr != "" {
+				if err == nil {
+					t.Fatalf("expected error %q, got nil", tc.wantErr)
+				}
+				if !strings.Contains(err.Error(), tc.wantErr) {
+					t.Fatalf("expected error containing %q, got %q", tc.wantErr, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("expected %q, got %q", tc.want, got)
+			}
+		})
+	}
+}
+
+func TestExpandSecretProviderPlaceholders(t *testing.T) {
+	t.Setenv("MCPJ_TEST_HOST", "example.com")
+	provider := &fakeProvider{
+		values: map[string]string{
+			"github-token":     "secret-token",
+			"mcpjungle/nested": "nested-secret",
+		},
+	}
+	resolver := NewResolver(map[string]SecretProvider{"keychain": provider})
+
+	testCases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr string
+	}{
+		{
+			name:  "keychain placeholder",
+			input: "${keychain:github-token}",
+			want:  "secret-token",
+		},
+		{
+			name:  "opaque provider key",
+			input: "${keychain:mcpjungle/nested}",
+			want:  "nested-secret",
+		},
+		{
+			name:  "multiple provider and environment placeholders",
+			input: "https://${MCPJ_TEST_HOST}/mcp?first=${keychain:github-token}&second=${keychain:mcpjungle/nested}",
+			want:  "https://example.com/mcp?first=secret-token&second=nested-secret",
+		},
+		{
+			name:    "unknown provider",
+			input:   "${vault:github-token}",
+			wantErr: `unsupported secret provider "vault"`,
+		},
+		{
+			name:    "empty provider key",
+			input:   "${keychain:}",
+			wantErr: `invalid secret reference "keychain:"`,
+		},
+		{
+			name:    "provider error",
+			input:   "${keychain:missing}",
+			wantErr: `fake secret "missing" was not found`,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := expandEnvPlaceholders(tc.input)
+			got, err := resolver.expandPlaceholders(tc.input)
 			if tc.wantErr != "" {
 				if err == nil {
 					t.Fatalf("expected error %q, got nil", tc.wantErr)
@@ -129,6 +201,51 @@ func TestResolveConfigEnvVars(t *testing.T) {
 	}
 }
 
+func TestResolverResolvesSecretsInNestedValues(t *testing.T) {
+	type nestedConfig struct {
+		BearerToken string
+		Headers     map[string]string
+	}
+
+	cfg := struct {
+		Env    map[string]string
+		Args   []string
+		Nested any
+	}{
+		Env: map[string]string{
+			"GITHUB_TOKEN": "${keychain:github-token}",
+		},
+		Args: []string{"--token=${keychain:github-token}"},
+		Nested: nestedConfig{
+			BearerToken: "${keychain:github-token}",
+			Headers: map[string]string{
+				"Authorization": "Bearer ${keychain:github-token}",
+			},
+		},
+	}
+
+	resolver := NewResolver(map[string]SecretProvider{
+		"keychain": &fakeProvider{values: map[string]string{"github-token": "secret-token"}},
+	})
+	if err := resolver.Resolve(&cfg); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if cfg.Env["GITHUB_TOKEN"] != "secret-token" {
+		t.Fatalf("expected resolved environment value, got %q", cfg.Env["GITHUB_TOKEN"])
+	}
+	if cfg.Args[0] != "--token=secret-token" {
+		t.Fatalf("expected resolved argument, got %q", cfg.Args[0])
+	}
+	nested := cfg.Nested.(nestedConfig)
+	if nested.BearerToken != "secret-token" {
+		t.Fatalf("expected resolved bearer token, got %q", nested.BearerToken)
+	}
+	if nested.Headers["Authorization"] != "Bearer secret-token" {
+		t.Fatalf("expected resolved header, got %q", nested.Headers["Authorization"])
+	}
+}
+
 func TestResolveConfigEnvVarsMissingVariable(t *testing.T) {
 	cfg := struct {
 		URL string
@@ -143,4 +260,16 @@ func TestResolveConfigEnvVarsMissingVariable(t *testing.T) {
 	if !strings.Contains(err.Error(), "environment variable MCPJ_TEST_NOT_SET is not set") {
 		t.Fatalf("unexpected error: %v", err)
 	}
+}
+
+type fakeProvider struct {
+	values map[string]string
+}
+
+func (p *fakeProvider) Resolve(key string) (string, error) {
+	value, ok := p.values[key]
+	if !ok {
+		return "", fmt.Errorf("fake secret %q was not found", key)
+	}
+	return value, nil
 }

--- a/internal/configresolver/keychain_provider.go
+++ b/internal/configresolver/keychain_provider.go
@@ -1,0 +1,57 @@
+package configresolver
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/user"
+	"strings"
+
+	keyring "github.com/zalando/go-keyring"
+)
+
+type keychainProvider struct {
+	currentUsername func() (string, error)
+	get             func(service, account string) (string, error)
+}
+
+func newKeychainProvider() SecretProvider {
+	return keychainProvider{
+		currentUsername: currentUsername,
+		get:             keyring.Get,
+	}
+}
+
+func (p keychainProvider) Resolve(key string) (string, error) {
+	account, err := p.currentUsername()
+	if err != nil {
+		return "", fmt.Errorf("failed to determine account for keychain secret %q: %w", key, err)
+	}
+
+	value, err := p.get(key, account)
+	if errors.Is(err, keyring.ErrNotFound) {
+		return "", fmt.Errorf("keychain secret %q was not found", key)
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to resolve keychain secret %q: %w", key, err)
+	}
+
+	return value, nil
+}
+
+func currentUsername() (string, error) {
+	for _, name := range []string{"USER", "USERNAME"} {
+		if value := strings.TrimSpace(os.Getenv(name)); value != "" {
+			return value, nil
+		}
+	}
+
+	current, err := user.Current()
+	if err != nil {
+		return "", err
+	}
+	if current.Username == "" {
+		return "", fmt.Errorf("current OS user has no username")
+	}
+	return current.Username, nil
+}

--- a/internal/configresolver/keychain_provider_test.go
+++ b/internal/configresolver/keychain_provider_test.go
@@ -1,0 +1,111 @@
+package configresolver
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	keyring "github.com/zalando/go-keyring"
+)
+
+func TestKeychainProviderUsesKeyAsServiceAndCurrentUserAsAccount(t *testing.T) {
+	var gotService string
+	var gotAccount string
+	provider := keychainProvider{
+		currentUsername: func() (string, error) { return "alice", nil },
+		get: func(service, account string) (string, error) {
+			gotService = service
+			gotAccount = account
+			return "secret-token", nil
+		},
+	}
+
+	value, err := provider.Resolve("github-token")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if value != "secret-token" {
+		t.Fatalf("expected resolved secret, got %q", value)
+	}
+	if gotService != "github-token" {
+		t.Fatalf("expected service %q, got %q", "github-token", gotService)
+	}
+	if gotAccount != "alice" {
+		t.Fatalf("expected account %q, got %q", "alice", gotAccount)
+	}
+}
+
+func TestKeychainProviderMissingSecret(t *testing.T) {
+	provider := keychainProvider{
+		currentUsername: func() (string, error) { return "alice", nil },
+		get: func(_, _ string) (string, error) {
+			return "", keyring.ErrNotFound
+		},
+	}
+
+	_, err := provider.Resolve("missing-token")
+	if err == nil || err.Error() != `keychain secret "missing-token" was not found` {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestKeychainProviderBackendErrorDoesNotExposeValue(t *testing.T) {
+	provider := keychainProvider{
+		currentUsername: func() (string, error) { return "alice", nil },
+		get: func(_, _ string) (string, error) {
+			return "must-not-appear", errors.New("keychain access denied")
+		},
+	}
+
+	_, err := provider.Resolve("github-token")
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), `failed to resolve keychain secret "github-token": keychain access denied`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if strings.Contains(err.Error(), "must-not-appear") {
+		t.Fatalf("error exposed the secret value: %v", err)
+	}
+}
+
+func TestKeychainProviderUsernameError(t *testing.T) {
+	provider := keychainProvider{
+		currentUsername: func() (string, error) { return "", errors.New("user lookup failed") },
+		get: func(_, _ string) (string, error) {
+			t.Fatal("keychain should not be queried when user lookup fails")
+			return "", nil
+		},
+	}
+
+	_, err := provider.Resolve("github-token")
+	if err == nil || !strings.Contains(err.Error(), `failed to determine account for keychain secret "github-token": user lookup failed`) {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCurrentUsernamePrefersUserEnvironmentVariable(t *testing.T) {
+	t.Setenv("USER", "alice")
+	t.Setenv("USERNAME", "windows-alice")
+
+	username, err := currentUsername()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if username != "alice" {
+		t.Fatalf("expected USER value, got %q", username)
+	}
+}
+
+func TestCurrentUsernameFallsBackToUsernameEnvironmentVariable(t *testing.T) {
+	t.Setenv("USER", "")
+	t.Setenv("USERNAME", "windows-alice")
+
+	username, err := currentUsername()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if username != "windows-alice" {
+		t.Fatalf("expected USERNAME value, got %q", username)
+	}
+}


### PR DESCRIPTION
## Summary

- generalize CLI configuration interpolation with a mockable secret-provider resolver
- resolve `${keychain:<key>}` from the native OS keychain using the key as the service and current username as the account
- preserve existing `${ENV_VAR}` behavior, document platform setup, and warn about downstream plaintext handling

Closes #299.

## Pre-Agreement Checklist (required)

- [x] I have read and followed the [contribution guidelines](https://docs.mcpjungle.com/developers/contributing).
- [x] This PR addresses an existing issue or a concluded discussion.
- [x] If there was no existing issue/discussion, I opened one first to align with maintainers before submitting the PR.
- [ ] I confirmed the issue/discussion priority with maintainers and understand low-priority items may receive limited attention.
- [x] I kept this PR focused and reasonably small; if the work is large, I split it into smaller PRs where possible.
- [ ] Any AI-generated code in this PR was reviewed by a human author.

## Validation Checklist

- [x] `go test ./...` passes locally.
- [x] `scripts/test-mcpjungle.sh` passes locally.
- [x] I added or updated tests for new behavior where applicable.
- [x] I updated documentation for user-facing changes where applicable.

Additional validation:

- `go vet ./internal/configresolver ./cmd`
- `go test -race ./internal/configresolver`
- cross-compiled the resolver tests for Windows and Linux with `CGO_ENABLED=0`

## Linked Context

- Issue(s): #299
- Discussion(s): None

## Security boundary

Resolution happens in the CLI before registration. Secret values are never included in resolver errors, but the resolved plaintext is still sent to the MCPJungle server and may be persisted under the existing registration semantics.
