### PR TITLE
Docs: optional TOA verify before MCPJungle register

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Start with a local setup. Scale to a shared team gateway when you need it.
  
  Your AI Clients can also access the docs using its MCP server `https://docs.mcpjungle.com/mcp`!
 
+Optional offline delivery-evidence gate before register: [docs/guides/toa-optional-register-gate.mdx](docs/guides/toa-optional-register-gate.mdx).
+
 ## Quickstart
 
 This quickstart guide will show you how to:

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -50,7 +50,8 @@
               "guides/manage-resources",
               "guides/tool-groups",
               "guides/session-modes",
-              "guides/register-popular-servers"
+              "guides/register-popular-servers",
+              "guides/toa-optional-register-gate"
             ]
           },
           {

--- a/docs/guides/toa-optional-register-gate.mdx
+++ b/docs/guides/toa-optional-register-gate.mdx
@@ -1,0 +1,33 @@
+---
+title: Optional TOA verify before register
+description: Offline Tool Outcome Attestation before registering an MCP server
+---
+
+MCPJungle registers MCP servers once and exposes a unified gateway. Registration and access control answer inventory and who may call what. They do not prove that a tool recently delivered a real result under an outside probe.
+
+[TOA](https://github.com/Carmel-Labs-Inc/toa) (`toa/0.1`) is an Apache-2.0 signed JSON evidence format for MCP tool delivery (reach, invoke, functional, shape, and related layers). It is not a wire protocol. It is not meant to run on every live `tools/call`.
+
+## Suggested fit
+
+Optional, off by default. Before `mcpjungle register` (or promoting a server into a shared team gateway), require a recent attestation and verify it offline with a pinned emitter public key.
+
+- Any party can emit if they sign the schema.
+- AgentStatus is one optional emitter.
+- No AgentStatus account is required to verify.
+
+```yaml
+      # After your register dry-run / smoke checks.
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass
+```
+
+Copy-paste: `examples/toa-after-register.yml` in this repository.
+
+## Out of scope
+
+- Replacing MCPJungle access control or upstream authentication
+- Signing every production `tools/call`
+- Changing gateway runtime code

--- a/docs/guides/toa-optional-register-gate.mdx
+++ b/docs/guides/toa-optional-register-gate.mdx
@@ -20,7 +20,7 @@ Optional, off by default. Before `mcpjungle register` (or promoting a server int
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 

--- a/docs/guides/toa-optional-register-gate.mdx
+++ b/docs/guides/toa-optional-register-gate.mdx
@@ -9,7 +9,7 @@ MCPJungle registers MCP servers once and exposes a unified gateway. Registration
 
 ## Suggested fit
 
-Optional, off by default. Before `mcpjungle register` (or promoting a server into a shared team gateway), require a recent attestation and verify it offline with a pinned emitter public key.
+Optional, off by default. Before `mcpjungle register` (or promoting a server into a shared team gateway), require an attestation and verify it offline with `--require-emitter` and optional `--max-age`.
 
 - Any party can emit if they sign the schema.
 - AgentStatus is one optional emitter.
@@ -20,8 +20,8 @@ Optional, off by default. Before `mcpjungle register` (or promoting a server int
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d
 ```
 
 Copy-paste: `examples/toa-after-register.yml` in this repository.

--- a/examples/toa-after-register.yml
+++ b/examples/toa-after-register.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
-          toa-verify toa.json --require-layer functional=pass
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/toa-after-register.yml
+++ b/examples/toa-after-register.yml
@@ -12,5 +12,5 @@ jobs:
       - name: Verify tool delivery attestation
         if: hashFiles('toa.json') != ''
         run: |
-          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@5a1bf1cf6a15a4864ea809fe7b2a073f2cef4e22#subdirectory=python"
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@99e2690fec24a5290d9542e58383a8bf753e8b74#subdirectory=python"
           toa-verify toa.json --require-emitter agentstatus --require-layer functional=pass --max-age 7d

--- a/examples/toa-after-register.yml
+++ b/examples/toa-after-register.yml
@@ -1,0 +1,16 @@
+# Example only. Copy into your org workflow as needed.
+name: MCPJungle register and optional TOA
+on:
+  workflow_dispatch:
+  pull_request:
+    paths: ["toa.json"]
+jobs:
+  toa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify tool delivery attestation
+        if: hashFiles('toa.json') != ''
+        run: |
+          pip install "git+https://github.com/Carmel-Labs-Inc/toa.git@345f24607919b5bdf143719b9ea062543cdfe88e#subdirectory=python"
+          toa-verify toa.json --require-layer functional=pass


### PR DESCRIPTION
## Summary

Docs-only. Optional offline `toa-verify` before registering an MCP server in MCPJungle.

- `docs/guides/toa-optional-register-gate.mdx` + Mintlify nav
- `examples/toa-after-register.yml`
- README pointer

Does not change gateway runtime. No AgentStatus account required to verify.

## Test plan

- [ ] Docs page appears under Servers and Tools
- [ ] Example YAML clearly optional / gated on `toa.json`

Made with [Cursor](https://cursor.com)